### PR TITLE
A variety of Constraint variants and behaviors (i.e. Ropes, Springs, Welds...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <img src="https://doy2mn9upadnk.cloudfront.net/uploads/default/original/4X/e/7/0/e709b34f89add2336a7d74faee3b2a839a9391b0.png" width="480" /><br/><br/>
-    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/35"><img alt="version" src="https://img.shields.io/badge/v0.2.4--beta-version-%231FD67F"></img></a>
+    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/35"><img alt="version" src="https://img.shields.io/badge/v0.3.0--beta-version-%231FD67F"></img></a>
     <br/>
     <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/"><img alt="devforum" src="https://img.shields.io/badge/topic-devforum-white"></img></a>
     <a href="https://www.roblox.com/library/7625799164/Nature2D"><img alt="model" src="https://img.shields.io/badge/asset-roblox-white"></img></a>
@@ -30,7 +30,7 @@ https://www.roblox.com/library/7625799164/Nature2D
 * **Using wally** - Use [wally](https://github.com/UpliftGames/wally), a package manager for roblox to install Nature2D in your external code editor! This requires wally to be installed on your device. Then, add Nature2D to the dependencies listed in your `wally.toml` file!<br/>
 ```toml
 [dependencies]
-Nature2D = "jaipack17/nature2d@0.2.4"
+Nature2D = "jaipack17/nature2d@0.3.0"
 ```
 After that, Run `wally install` in the CLI! Nature2D should be installed in your root directory. If you encounter any errors or problems installing Nature2D using wally, [open an issue!](https://github.com/jaipack17/Nature2D/issues)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
     <img src="https://doy2mn9upadnk.cloudfront.net/uploads/default/original/4X/e/7/0/e709b34f89add2336a7d74faee3b2a839a9391b0.png" width="480" /><br/><br/>
-    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/35"><img alt="version" src="https://img.shields.io/badge/v0.2.4--beta-version-green"></img></a>
+    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/35"><img alt="version" src="https://img.shields.io/badge/v0.2.4--beta-version-%231FD67F"></img></a>
     <br/>
-    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/"><img alt="devforum" src="https://img.shields.io/badge/post-devforum-blue"></img></a>
-    <a href="https://www.roblox.com/library/7625799164/Nature2D"><img alt="model" src="https://img.shields.io/badge/asset-roblox-%23FF0000"></img></a>
-    <a href="https://jaipack17.github.io/Nature2D/"><img alt="documentation" src="https://img.shields.io/badge/docs-website-orange"></img></a>
+    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/"><img alt="devforum" src="https://img.shields.io/badge/topic-devforum-white"></img></a>
+    <a href="https://www.roblox.com/library/7625799164/Nature2D"><img alt="model" src="https://img.shields.io/badge/asset-roblox-white"></img></a>
+    <a href="https://jaipack17.github.io/Nature2D/"><img alt="documentation" src="https://img.shields.io/badge/docs-website-white"></img></a>
 </div>
 
 # About

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -247,6 +247,9 @@ function Engine:CreateConstraint(Type: string, point1: Types.Point, point2: Type
 	if not table.find(Globals.constraint.types, string.lower(Type)) then 
 		throwException("error", "INVALID_CONSTRAINT_TYPE")
 	end
+	
+	if restLength and restLength <= 0 then throwException("error", "INVALID_CONSTRAINT_LENGTH") end
+	if thickness and thickness <= 0 then throwException("error", "INVALID_CONSTRAINT_THICKNESS") end
 
 	local dist = (point2.pos - point1.pos).Magnitude
 		

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -238,17 +238,23 @@ end
 	[RETURNS]: Constraint
 ]]--
 
-function Engine:CreateConstraint(point1: Types.Point, point2: Types.Point, visible: boolean, thickness: number)
+function Engine:CreateConstraint(Type: string, point1: Types.Point, point2: Types.Point, visible: boolean, thickness: number)
+	throwTypeError("type", Type, 1, "string")
 	throwTypeError("visible", visible, 3, "boolean")
 	throwTypeError("thickness", thickness, 4, "number")
+	
+	if not table.find(Globals.constraint.types, string.lower(Type)) then 
+		throwException("error", "INVALID_CONSTRAINT_TYPE")
+	end
 
 	local dist = (point2.pos - point1.pos).Magnitude
-
+		
 	local newConstraint = Constraint.new(point1, point2, self.canvas, {
 		restLength = dist, 
 		render = visible, 
 		thickness = thickness,
-		support = true
+		support = true,
+		TYPE = string.upper(Type)
 	}, self)
 
 	table.insert(self.constraints, newConstraint)

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -238,11 +238,12 @@ end
 	[RETURNS]: Constraint
 ]]--
 
-function Engine:CreateConstraint(Type: string, point1: Types.Point, point2: Types.Point, visible: boolean, thickness: number)
+function Engine:CreateConstraint(Type: string, point1: Types.Point, point2: Types.Point, visible: boolean, thickness: number, restLength: number)
 	throwTypeError("type", Type, 1, "string")
 	throwTypeError("visible", visible, 3, "boolean")
 	throwTypeError("thickness", thickness, 4, "number")
-	
+	throwTypeError("restLength", restLength, 5, "number")
+
 	if not table.find(Globals.constraint.types, string.lower(Type)) then 
 		throwException("error", "INVALID_CONSTRAINT_TYPE")
 	end
@@ -250,7 +251,7 @@ function Engine:CreateConstraint(Type: string, point1: Types.Point, point2: Type
 	local dist = (point2.pos - point1.pos).Magnitude
 		
 	local newConstraint = Constraint.new(point1, point2, self.canvas, {
-		restLength = dist, 
+		restLength = restLength or dist, 
 		render = visible, 
 		thickness = thickness,
 		support = true,

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -58,17 +58,12 @@ export type RigidBody = {
 	States: { any }
 }
 
-export type Exceptions = {
-	NO_CANVAS_FOUND: string,
-	NO_RIGIDBODIES_FOUND: string,
-	PROPERTY_NOT_FOUND: string,
-}
-
 export type SegmentConfig = {
 	restLength: number?, 
 	render: boolean, 
 	thickness: number,
-	support: boolean
+	support: boolean,
+	TYPE: string,
 }
 
 export type EngineConfig = {

--- a/src/constants/Globals.lua
+++ b/src/constants/Globals.lua
@@ -26,7 +26,6 @@ return {
 		types = {
 			"rope",
 			"spring",
-			"weld",
 			"rod"
 		}
 	},

--- a/src/constants/Globals.lua
+++ b/src/constants/Globals.lua
@@ -23,6 +23,12 @@ return {
 	constraint = {
 		color = Color3.new(1, 1, 1),
 		thickness = 4,
+		types = {
+			"rope",
+			"spring",
+			"weld",
+			"rod"
+		}
 	},
 	point = {
 		radius = 2.5,

--- a/src/debug/Exceptions.lua
+++ b/src/debug/Exceptions.lua
@@ -6,7 +6,8 @@ local TYPES = {
 	NO_CANVAS_FOUND = "[Nature2D]: No canvas found, initialize the engine's canvas using Engine:CreateCanvas().",
 	NO_RIGIDBODIES_FOUND = "[Nature2D]: No rigid bodies found on start.",
 	PROPERTY_NOT_FOUND = "[Nature2D]: Invalid Argument #1. Property not found.",
-	INVALID_CONSTRAINT_TYPE = "[Nature2D]: Received Invalid Constraint Type."
+	INVALID_CONSTRAINT_TYPE = "[Nature2D]: Received Invalid Constraint Type.",
+	INVALID_CONSTRAINT_LENGTH = "[Nature2D]: Received Invalid Constraint Length."
 }
 
 return function (TASK: string, TYPE: string)

--- a/src/debug/Exceptions.lua
+++ b/src/debug/Exceptions.lua
@@ -2,20 +2,19 @@
 	Handling exceptions
 ]]--
 
-local Types = require(script.Parent.Parent.Types)
-
-local EXCEPTIONS: Types.Exceptions = {
+local TYPES = {
 	NO_CANVAS_FOUND = "[Nature2D]: No canvas found, initialize the engine's canvas using Engine:CreateCanvas().",
 	NO_RIGIDBODIES_FOUND = "[Nature2D]: No rigid bodies found on start.",
 	PROPERTY_NOT_FOUND = "[Nature2D]: Invalid Argument #1. Property not found.",
+	INVALID_CONSTRAINT_TYPE = "[Nature2D]: Received Invalid Constraint Type."
 }
 
 return function (TASK: string, TYPE: string)
-	if EXCEPTIONS[TYPE] then 
+	if TYPES[TYPE] then 
 		if TASK == "warn" then 
-			warn(EXCEPTIONS[TYPE])
+			warn(TYPES[TYPE])
 		elseif TASK == "error" then 
-			error(EXCEPTIONS[TYPE], 2)
+			error(TYPES[TYPE], 2)
 		end
 	end
 end

--- a/src/debug/Exceptions.lua
+++ b/src/debug/Exceptions.lua
@@ -7,7 +7,8 @@ local TYPES = {
 	NO_RIGIDBODIES_FOUND = "[Nature2D]: No rigid bodies found on start.",
 	PROPERTY_NOT_FOUND = "[Nature2D]: Invalid Argument #1. Property not found.",
 	INVALID_CONSTRAINT_TYPE = "[Nature2D]: Received Invalid Constraint Type.",
-	INVALID_CONSTRAINT_LENGTH = "[Nature2D]: Received Invalid Constraint Length."
+	INVALID_CONSTRAINT_LENGTH = "[Nature2D]: Received Invalid Constraint Length.",
+	INVALID_CONSTRAINT_THICKNESS = "[Nature2D]: Received Invalid Constraint Thickness."
 }
 
 return function (TASK: string, TYPE: string)

--- a/src/physics/Constraint.lua
+++ b/src/physics/Constraint.lua
@@ -195,12 +195,28 @@ function Constraint:GetFrame() : Frame?
 	return self.frame
 end
 
+--[[
+	This method is used to update the Spring constant (by default 0.1) used for spring constraint calculations.
+
+	[METHOD]: Constraint:SetSpringConstant()
+	[PARAMETERS]: k: number 
+	[RETURNS]: nil
+]]--
+
 function Constraint:SetSpringConstant(k: number)
 	throwTypeError("springConstant", k, 1, "number")
 	self.k = k
 end
 
-function Constraint:GetId()
+--[[
+	The constraints's unique ID can be fetched using this method.
+
+	[METHOD]: Constraint:GetId()
+	[PARAMETERS]: none 
+	[RETURNS]: id: string
+]]--
+
+function Constraint:GetId() : string
 	return self.id
 end
 

--- a/src/physics/Constraint.lua
+++ b/src/physics/Constraint.lua
@@ -195,4 +195,13 @@ function Constraint:GetFrame() : Frame?
 	return self.frame
 end
 
+function Constraint:SetSpringConstant(k: number)
+	throwTypeError("springConstant", k, 1, "number")
+	self.k = k
+end
+
+function Constraint:GetId()
+	return self.id
+end
+
 return Constraint

--- a/src/physics/Constraint.lua
+++ b/src/physics/Constraint.lua
@@ -35,6 +35,7 @@ function Constraint.new(p1: Types.Point, p2: Types.Point, canvas: Types.Canvas, 
 		render = config.render,
 		thickness = config.thickness,
 		support = config.support,
+		_TYPE = config.TYPE,
 		color = nil,
 	}, Constraint)
 
@@ -50,19 +51,21 @@ end
 ]]--
 
 function Constraint:Constrain()
-	local cur = (self.point2.pos - self.point1.pos).Magnitude
-	local offset = ((self.restLength - cur) / cur)/2
+	if self._TYPE == "ROPE" then 
+		local cur = (self.point2.pos - self.point1.pos).Magnitude
+		local offset = ((self.restLength - cur) / cur)/2
+		
+		local dir = self.point2.pos 
+		dir -= self.point1.pos 
+		dir *= offset
+		
+		if not self.point1.snap then
+			self.point1.pos -= dir
+		end
 
-	local dir = self.point2.pos 
-	dir -= self.point1.pos 
-	dir *= offset
-
-	if not self.point1.snap then
-		self.point1.pos -= dir
-	end
-
-	if not self.point2.snap then
-		self.point2.pos += dir
+		if not self.point2.snap then
+			self.point2.pos += dir
+		end		
 	end
 end
 

--- a/src/physics/Constraint.lua
+++ b/src/physics/Constraint.lua
@@ -51,22 +51,23 @@ end
 ]]--
 
 function Constraint:Constrain()
+	local cur = (self.point2.pos - self.point1.pos).Magnitude
+	local offset
+	
 	if self._TYPE == "ROPE" then 
-		local cur = (self.point2.pos - self.point1.pos).Magnitude
-		local offset = ((self.restLength - cur) / cur)/2
-		
-		local dir = self.point2.pos 
-		dir -= self.point1.pos 
-		dir *= offset
-		
-		if not self.point1.snap then
-			self.point1.pos -= dir
-		end
-
-		if not self.point2.snap then
-			self.point2.pos += dir
-		end		
+		offset = ((self.restLength - cur)/cur)/5
+	elseif self._TYPE == "ROD" then 
+		offset = ((self.restLength - cur)/self.restLength)/2		
+	else 
+		return
 	end
+	
+	local dir = self.point2.pos 
+	dir -= self.point1.pos 
+	dir *= offset
+
+	if not self.point1.snap then self.point1.pos -= dir end
+	if not self.point2.snap then self.point2.pos += dir end		
 end
 
 --[[

--- a/src/physics/RigidBody.lua
+++ b/src/physics/RigidBody.lua
@@ -127,7 +127,7 @@ function RigidBody.new(frame: GuiObject, m: number, collidable: boolean, anchore
 		render = false, 
 		thickness = 4,
 		support = false,
-		TYPE = "ROPE"
+		TYPE = "ROD"
 	}
 
 	local function addPoint(pos)

--- a/src/physics/RigidBody.lua
+++ b/src/physics/RigidBody.lua
@@ -126,7 +126,8 @@ function RigidBody.new(frame: GuiObject, m: number, collidable: boolean, anchore
 		restLength = nil, 
 		render = false, 
 		thickness = 4,
-		support = false
+		support = false,
+		TYPE = "ROPE"
 	}
 
 	local function addPoint(pos)


### PR DESCRIPTION
To complete the release of Nature2D v0.3, I decided to add a variety of new constraints to the library. With different behaviors, usages and appearances (not sure). 

<hr/>

### What all Constraint Types?

v0.3 will consist of 4 constraint variants. 

* **Rope Constraints** - Constraints used all across the library up till v0.2 were Rope Constraints. They were rather simple compared to the new ones. They will continue to remain the default constraints of the library in v0.3 just with the addition of other types of constraints to open gates for a wide heterogeneity of simulations. 

* **Rod Constraints** -  These constraints are similar to how Rope constraints function. But unlike rope constraints, these constraints have a fixed amount of space between its points and aren't flexible. These constraints can move in all directions just how rope constraints can, but the space between them remains constant. 

* **Spring Constraints** - Spring constraints are elastic, wonky and flexible. Perfect for various simulations that require springs. Achieved using Hooke's Law.

* **Weld Constraints** - Welds are used to stick/join two RigidBodies while maintaining their rigidity. Similar to how rod constraints function, they maintain constant gaps between its points. But unlike rods, these constraints are stiff and cannot be rotated. These can be used to create stiff joints between multiple RigidBodies. 

This PR will remain a draft until all constraints are functional and revised. See you around!
  


