### PR TITLE
Fix and Improve Frictional Forces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Releases
 
+## v0.3.2 - Major Improvements to Frictional Forces
+
+* Fixed a bug where changes to physical properties before creating any RigidBodies, Constraints or Points won't affect/apply to newly created objects.
+* Friction only applies if RigidBodies collide with each other or the edges of the canvas. If none of those conditions are true, AirFriction is applied.
+* Added AirFriction physical property to Engine, Points and RigidBodies. Frictional force applied when a RigidBody neither touches another body nor the edges of canvas.
+   * `Engine:SetPhysicalProperty("AirFriction", 0.1)`
+* Friction and AirFriction are set to 0.01 by default. (0.99 damping value).
+* Changed how we pass parameters when initializing or updating friction of the engine or rigidbodies. The closer the friction to 1, the higher it is. The closer the friction to 0, the lower it is. Same applies for AirFriction. Values not in the range of 0-1 are automatically clamped down.
+* Added new Methods to RigidBodies
+  * `RigidBody:SetAirFriction(airfriction: number)`
+
 ## v0.3.1 - Fixes to Collision Detection & New Methods
 
 * Made `restLength: number?` an optional parameter for `Engine:CreateConstraint()`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <img src="https://doy2mn9upadnk.cloudfront.net/uploads/default/original/4X/e/7/0/e709b34f89add2336a7d74faee3b2a839a9391b0.png" width="480" /><br/><br/>
-    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/38"><img alt="version" src="https://img.shields.io/badge/v0.3.1--beta-version-%231FD67F"></img></a>
+    <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/39"><img alt="version" src="https://img.shields.io/badge/v0.3.2--beta-version-%231FD67F"></img></a>
     <br/>
     <a href="https://devforum.roblox.com/t/physics-library-nature2d-bring-ui-elements-to-life/1510935/"><img alt="devforum" src="https://img.shields.io/badge/topic-devforum-white"></img></a>
     <a href="https://www.roblox.com/library/7625799164/Nature2D"><img alt="model" src="https://img.shields.io/badge/asset-roblox-white"></img></a>
@@ -30,7 +30,7 @@ https://www.roblox.com/library/7625799164/Nature2D
 * **Using wally** - Use [wally](https://github.com/UpliftGames/wally), a package manager for roblox to install Nature2D in your external code editor! This requires wally to be installed on your device. Then, add Nature2D to the dependencies listed in your `wally.toml` file!<br/>
 ```toml
 [dependencies]
-Nature2D = "jaipack17/nature2d@0.3.1"
+Nature2D = "jaipack17/nature2d@0.3.2"
 ```
 After that, Run `wally install` in the CLI! Nature2D should be installed in your root directory. If you encounter any errors or problems installing Nature2D using wally, [open an issue!](https://github.com/jaipack17/Nature2D/issues)
 

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -26,6 +26,7 @@ export type Point = {
 	forces: Vector2,
 	gravity: Vector2,
 	friction: number,
+	airfriction: number,
 	bounce: number,
 	snap: boolean,
 	selectable: boolean,
@@ -71,6 +72,7 @@ export type EngineConfig = {
 	friction: number,
 	bounce: number,
 	speed: number,
+	airfriction: number,
 }
 
 export type PointConfig = {

--- a/src/constants/Globals.lua
+++ b/src/constants/Globals.lua
@@ -6,6 +6,7 @@ return {
 	engineInit = {
 		gravity = Vector2.new(0, .3),
 		friction = 0.99,
+		airfriction = 0.99,
 		bounce = 0.8,
 		timeSteps = 1,
 		canvas = {
@@ -19,6 +20,7 @@ return {
 		"gravity",
 		"friction",
 		"collisionmultiplier",
+		"airfriction",
 	},
 	constraint = {
 		color = Color3.new(1, 1, 1),

--- a/src/physics/Point.lua
+++ b/src/physics/Point.lua
@@ -68,7 +68,9 @@ function Point:Update(dt: number)
 		local velocity = self.pos 
 		velocity -= self.oldPos
 		velocity += self.forces * dt * self.engine.speed
-		velocity *= self.friction 
+		velocity *= self.friction
+
+                -- fix friction
 
 		self.oldPos = self.pos
 		self.pos += velocity

--- a/src/physics/RigidBody.lua
+++ b/src/physics/RigidBody.lua
@@ -175,6 +175,10 @@ function RigidBody.new(frame: GuiObject, m: number, collidable: boolean, anchore
 		anchorPos = anchored and frame.AbsolutePosition or nil,
 		Touched = nil,
 		CanvasEdgeTouched = nil,
+		Collisions = {			
+			Body = false,
+			CanvasEdge = false,
+		},
 		States = {}
 	}, RigidBody)
 
@@ -575,7 +579,23 @@ function RigidBody:SetFriction(friction: number)
 	throwTypeError("friction", friction, 1, "number")
 
 	for _, p in ipairs(self.vertices) do
-		p.friction = friction
+		p.friction =  math.clamp(1 - friction, 0, 1)
+	end
+end
+
+--[[
+	This method sets a custom air frictional damp value just for the RigidBody.
+
+	[METHOD]: RigidBody:SetAirFriction()
+	[PARAMETERS]: friction: number
+	[RETURNS]: nil
+]]--
+
+function RigidBody:SetAirFriction(friction: number)
+	throwTypeError("friction", friction, 1, "number")
+
+	for _, p in ipairs(self.vertices) do
+		p.airfriction =  math.clamp(1 - friction, 0, 1)
 	end
 end
 

--- a/wally.toml
+++ b/wally.toml
@@ -2,7 +2,7 @@
 name = "jaipack17/nature2d"
 description = "Create versatile physics simulations and mechanics with Guis on Roblox!"
 authors = ["jaipack17"]
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Currently friction is nothing but a simple damping value. It works fine for most of the time, countering this - Friction isn't supposed to be active even when two Bodies aren't in contact with each other. As of now, Friction forces act even if two RigidBodies or other objects aren't in contact with each other. 

This is something I wish to fix. I also wish to improve the way you pass in parameters when updating the global or local frictional damping value. The parameters take in an alpha value. But it acts as an inverse! If friction is 0, aren't the Bodies supposed to move infinitely and never stop? Well that's expected, but isn't the actual result! Setting friction to 0 makes it impossible for a Body to move. The closer the friction to 0, the higher it is. 

I aim to change this. The closer the friction to 0, the lower it is supposed to be.

This PR will remain a draft until all updates are made and revised.