### PR TITLE
Optimizations

### DIFF
--- a/src/Constants/Globals.lua
+++ b/src/Constants/Globals.lua
@@ -78,7 +78,7 @@ return {
 		}
 	},
 	offset = Vector2.new(0, 36),
-	
+
 	VALID_OBJECT_PROPS = {
 		"Position",
 		"Visible",
@@ -89,7 +89,7 @@ return {
 		"Type",
 		"Point1",
 		"Point2",
-		"Thickness", 
+		"Thickness",
 		"RestLength",
 		"SpringConstant",
 		"Object",
@@ -102,7 +102,7 @@ return {
 		"Structure",
 		"Mass"
 	},
-	
+
 	OBJECT_PROPS_TYPES = {
 		Position = "Vector2",
 		Visible = "boolean",
@@ -111,7 +111,7 @@ return {
 		Radius = "number",
 		Color = "Color3",
 		Type = "string",
-		Thickness = "number", 
+		Thickness = "number",
 		RestLength = "number",
 		SpringConstant = "number",
 		Object = "Instance",

--- a/src/Debugging/Exceptions.lua
+++ b/src/Debugging/Exceptions.lua
@@ -13,14 +13,15 @@ local TYPES = {
 	INVALID_PROPERTY = "Received an Invalid Object Property.",
 	MUST_HAVE_PROPERTY = "Missing must-have properties.",
 	CANVAS_FRAME_NOT_FOUND = "No canvas frame found, initialize the canvas's frame to render custom Points and Constraints!",
-	INVALID_TIME = "Received invalid time to apply force for."
+	INVALID_TIME = "Received invalid time to apply force for.",
+	ALREADY_STARTED = "Engine is already running."
 }
 
 return function (TASK: string, TYPE: string)
-	if TYPES[TYPE] then
-		if TASK == "warn" then
+	if TYPES[TYPE] then 
+		if TASK == "warn" then 
 			warn(TYPES[TYPE])
-		elseif TASK == "error" then
+		elseif TASK == "error" then 
 			error("[Nature2D]: "..TYPES[TYPE], 2)
 		end
 	end

--- a/src/Debugging/Exceptions.lua
+++ b/src/Debugging/Exceptions.lua
@@ -17,10 +17,10 @@ local TYPES = {
 }
 
 return function (TASK: string, TYPE: string)
-	if TYPES[TYPE] then 
-		if TASK == "warn" then 
+	if TYPES[TYPE] then
+		if TASK == "warn" then
 			warn(TYPES[TYPE])
-		elseif TASK == "error" then 
+		elseif TASK == "error" then
 			error("[Nature2D]: "..TYPES[TYPE], 2)
 		end
 	end

--- a/src/Debugging/Restrict.lua
+++ b/src/Debugging/Restrict.lua
@@ -1,5 +1,5 @@
 return function (custom)
-	if custom then 
+	if custom then
 		error("[Nature2D]: This method cannot be used with custom RigidBodies", 2)
 	end
 end

--- a/src/Debugging/TypeErrors.lua
+++ b/src/Debugging/TypeErrors.lua
@@ -9,7 +9,7 @@ return function (arg: string, param, pos: number, expected: string)
 				expected,
 				arg,
 				typeof(param)
-			),	
+			),
 			2
 		)
 	end

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -114,6 +114,7 @@ end
 function Engine:Start()
 	if not self.canvas then throwException("error", "NO_CANVAS_FOUND") end
 	if #self.bodies == 0 then throwException("warn", "NO_RIGIDBODIES_FOUND") end
+	if self.connection then throwException("warn", "ALREADY_STARTED") return end
 
 	-- Fire Engine.Started event
 	self.Started:Fire()
@@ -224,6 +225,11 @@ function Engine:Stop()
 	if self.connection then
 		self.Stopped:Fire()
 		self.connection:Disconnect()
+		self.Started:Destroy()
+		self.Stopped:Destroy()
+		self.ObjectAdded:Destroy()
+		self.ObjectRemoved:Destroy()
+		self.Updated:Destroy()
 		self.connection = nil
 	end
 end

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -134,8 +134,6 @@ function Engine:Start()
 		-- Update the body
 		-- Calculate the closest RigidBodies to a given body if neccesary
 		for _, body in ipairs(self.bodies) do 
-			body:Update(dt)
-
 			local filtered = self.bodies
 
 			if self.quadtrees then 
@@ -183,18 +181,8 @@ function Engine:Start()
 			
 			body.Collisions.Other = CollidingWith
 			
-			-- Render vertices of the body
-			for _, vertex in ipairs(body.vertices) do
-				vertex:Render()
-			end
-			
-			if body.custom then 
-				-- Render constraints of the body
-				for _, c in ipairs(body.edges) do 
-					c:Render()
-				end
-			end
-
+			-- Render and Update of the body
+			body:Update(dt)
 			body:Render()
 		end
 		

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -1,4 +1,4 @@
--- The Engine or the core of the library handles all the RigidBodies, constraints and points. 
+-- The Engine or the core of the library handles all the RigidBodies, constraints and points.
 -- It's responsible for the simulation of these elements and handling all tasks related to the library.
 
 -- Services and utilities
@@ -19,8 +19,8 @@ Engine.__index = Engine
 -- [PRIVATE]
 -- Search and return an element from a table using a lambda function
 local function SearchTable(t: { any }, a: any,  lambda: (a: any, b: any) -> boolean) : any
-	for _, v in ipairs(t) do 
-		if lambda(a, v) then 
+	for _, v in ipairs(t) do
+		if lambda(a, v) then
 			return v
 		end
 	end
@@ -31,54 +31,54 @@ end
 -- This method is responsible for separating two rigidbodies if they collide with each other.
 local function CollisionResponse(body: Types.RigidBody, other: Types.RigidBody, isColliding: boolean, Collision: Types.Collision, dt: number, oldCollidingWith)
 	if not isColliding then return end
-	
+
 	-- Fire the touched event
 	if not SearchTable(oldCollidingWith, other, function(a, b) return a.id == b.id end) then
 		body.Touched:Fire(other.id)
-	end	
-	
+	end
+
 	-- Calculate penetration in 2 dimensions
 	local penetration: Vector2 = Collision.axis * Collision.depth
 	local p1: Types.Point = Collision.edge.point1
 	local p2: Types.Point = Collision.edge.point2
-	
+
 	-- Calculate a t alpha value
 	local t
 	if math.abs(p1.pos.X - p2.pos.X) > math.abs(p1.pos.Y - p2.pos.Y) then
 		t = (Collision.vertex.pos.X - penetration.X - p1.pos.X)/(p2.pos.X - p1.pos.X)
-	else 
+	else
 		t = (Collision.vertex.pos.Y - penetration.Y - p1.pos.Y)/(p2.pos.Y - p1.pos.Y)
 	end
-	
+
 	-- Create a lambda
 	local factor: number = 1 / (t^2 + (1 - t)^2)
-	
+
 	-- Calculate masses
 	local bodyMass = Collision.edge.Parent.mass
 	local m = t * bodyMass + (1 - t) * bodyMass
 	local cMass = 1 / (m + Collision.vertex.Parent.Parent.mass)
-	
+
 	-- Calculate ratios of collision effects
 	local r1 = Collision.vertex.Parent.Parent.mass * cMass
 	local r2 = m * cMass
-	
+
 	-- If the body is not anchored, apply forces to the constraint
-	if not Collision.edge.Parent.anchored then 
+	if not Collision.edge.Parent.anchored then
 		p1.pos -= penetration * ((1 - t) * factor * r1)
 		p2.pos -= penetration * (t * factor * r1)
 	end
-	
+
 	-- If the body is not anchored, apply forces to the point
-	if not Collision.vertex.Parent.Parent.anchored then 	
+	if not Collision.vertex.Parent.Parent.anchored then
 		Collision.vertex.pos += penetration * r2
-	end	
+	end
 end
 
 -- [PUBLIC]
 -- This method is used to initialize basic configurations of the engine and allocate memory for future tasks.
 function Engine.init(screengui: Instance)
-	if not typeof(screengui) == "Instance" or not screengui:IsA("Instance") then 
-		error("Invalid Argument #1. 'screengui' must be a ScreenGui.", 2) 
+	if not typeof(screengui) == "Instance" or not screengui:IsA("Instance") then
+		error("Invalid Argument #1. 'screengui' must be a ScreenGui.", 2)
 	end
 
 	return setmetatable({
@@ -112,96 +112,101 @@ end
 function Engine:Start()
 	if not self.canvas then throwException("error", "NO_CANVAS_FOUND") end
 	if #self.bodies == 0 then throwException("warn", "NO_RIGIDBODIES_FOUND") end
-	
+
 	-- Fire Engine.Started event
 	self.Started:Fire()
-	
+
 	-- Create a RenderStepped connection
 	local connection;
 	connection = RunService.RenderStepped:Connect(function(dt)
 		local tree;
-		
+
 		-- Create a quadtree and insert bodies if neccesary
-		if self.quadtrees then 
+		if self.quadtrees then
 			tree = Quadtree.new(self.canvas.topLeft, self.canvas.size, 4)
 
-			for _, body in ipairs(self.bodies) do 
-				tree:Insert(body)
-			end			
+			for _, body in ipairs(self.bodies) do
+				if body.collidable then
+					tree:Insert(body)
+				end
+			end
 		end
-		
+
 		-- Loop through each body
 		-- Update the body
 		-- Calculate the closest RigidBodies to a given body if neccesary
-		for _, body in ipairs(self.bodies) do 
-			local filtered = self.bodies
-
-			if self.quadtrees then 
-				local abs = body.custom and body.size or body.frame.AbsoluteSize
-				local side = abs.X > abs.Y and abs.X or abs.Y
-
-				local range = {
-					position = body.center - Vector2.new(side * 1.5, side * 1.5),
-					size = Vector2.new(side * 3, side * 3)
-				}
-
-				filtered = tree:Search(range, {})				
-			end
-			
+		for _, body in ipairs(self.bodies) do
 			local OldCollidingWith = body.Collisions.Other
 			local CollidingWith = {}
-			
-			-- Loop through the filtered RigidBodies
-			-- Detect collisions
-			-- Process collision response
-			for _, other in ipairs(filtered) do 
-				if body.id ~= other.id and (body.collidable and other.collidable) and not table.find(body.filtered, other.id) then
-					local result = body:DetectCollision(other)
-					local isColliding = result[1]
-					local Collision = result[2]
-										
-					if isColliding then 
-						body.Collisions.Body = true
-						other.Collisions.Body = true
-						table.insert(CollidingWith, other)
-					else 
-						body.Collisions.Body = false
-						other.Collisions.Body = false
-						
-						-- Fire TouchEnded event
-						
-						if SearchTable(OldCollidingWith, other, function (a, b) return a.id == b.id end) then 
-							body.TouchEnded:Fire(other.id)
-						end
-					end
 
-					CollisionResponse(body, other, isColliding, Collision, dt, OldCollidingWith)
+			if body.collidable then
+
+				local filtered = self.bodies
+
+				if self.quadtrees then
+					local abs = body.custom and body.size or body.frame.AbsoluteSize
+					local side = abs.X > abs.Y and abs.X or abs.Y
+
+					local range = {
+						position = body.center - Vector2.new(side * 1.5, side * 1.5),
+						size = Vector2.new(side * 3, side * 3)
+					}
+
+					filtered = tree:Search(range, {})
+				end
+
+				-- Loop through the filtered RigidBodies
+				-- Detect collisions
+				-- Process collision response
+				for _, other in ipairs(filtered) do
+					if body.id ~= other.id and other.collidable and not table.find(body.filtered, other.id) then
+						local result = body:DetectCollision(other)
+						local isColliding = result[1]
+						local Collision = result[2]
+
+						if isColliding then
+							body.Collisions.Body = true
+							other.Collisions.Body = true
+							table.insert(CollidingWith, other)
+						else
+							body.Collisions.Body = false
+							other.Collisions.Body = false
+
+							-- Fire TouchEnded event
+
+							if SearchTable(OldCollidingWith, other, function (a, b) return a.id == b.id end) then
+								body.TouchEnded:Fire(other.id)
+							end
+						end
+
+						CollisionResponse(body, other, isColliding, Collision, dt, OldCollidingWith)
+					end
 				end
 			end
-			
+
 			body.Collisions.Other = CollidingWith
-			
-			-- Render and Update of the body
+        
+      -- Render and Update of the body
 			body:Update(dt)
 			body:Render()
 		end
-		
+
 		-- Render all custom constraints
-		if #self.constraints > 0 then 
-			for _, constraint in ipairs(self.constraints) do 
+		if #self.constraints > 0 then
+			for _, constraint in ipairs(self.constraints) do
 				constraint:Constrain()
 				constraint:Render()
-			end			
+			end
 		end
-		
+
 		-- Render all custom points
-		if #self.points > 0 then 
-			for _, point in ipairs(self.points) do 
+		if #self.points > 0 then
+			for _, point in ipairs(self.points) do
 				point:Update(dt)
 				point:Render()
 			end
 		end
-		
+
 		self.Updated:Fire()
 	end)
 
@@ -212,7 +217,7 @@ end
 function Engine:Stop()
 	-- Fire Engine.Stopped event
 	-- Disconnect all connections
-	if self.connection then 
+	if self.connection then
 		self.Stopped:Fire()
 		self.connection:Disconnect()
 		self.connection = nil
@@ -224,22 +229,22 @@ function Engine:Create(object: string, properties: Types.Properties)
 	-- Validate types of the object and property table
 	throwTypeError("object", object, 1, "string")
 	throwTypeError("properties", properties, 2, "table")
-	
+
 	-- Validate object
-	if object ~= "Constraint" and object ~= "Point" and object ~= "RigidBody" then 
+	if object ~= "Constraint" and object ~= "Point" and object ~= "RigidBody" then
 		throwException("error", "INVALID_OBJECT")
 	end
-	
+
 	-- Validate property table
-	for prop, value in pairs(properties) do 
-		if not table.find(Globals.VALID_OBJECT_PROPS, prop) or not table.find(Globals[string.lower(object)].props, prop) then 
+	for prop, value in pairs(properties) do
+		if not table.find(Globals.VALID_OBJECT_PROPS, prop) or not table.find(Globals[string.lower(object)].props, prop) then
 			throwException("error", "INVALID_PROPERTY")
 		end
-		
-		if Globals.OBJECT_PROPS_TYPES[prop] and typeof(value) ~= Globals.OBJECT_PROPS_TYPES[prop] then 
+
+		if Globals.OBJECT_PROPS_TYPES[prop] and typeof(value) ~= Globals.OBJECT_PROPS_TYPES[prop] then
 			error(
 				string.format(
-					"[Nature2D]: Invalid Property type for %q. Expected %q got %q.", 
+					"[Nature2D]: Invalid Property type for %q. Expected %q got %q.",
 					prop,
 					Globals.OBJECT_PROPS_TYPES[prop],
 					typeof(value)
@@ -248,33 +253,33 @@ function Engine:Create(object: string, properties: Types.Properties)
 			)
 		end
 	end
-	
+
 	-- Check if must-have properties exist in the property table
-	for _, prop in ipairs(Globals[string.lower(object)].must_have) do 
-		if not properties[prop] then 
+	for _, prop in ipairs(Globals[string.lower(object)].must_have) do
+		if not properties[prop] then
 			local throw = true
-			
-			if prop == "Object" and properties.Structure then 
+
+			if prop == "Object" and properties.Structure then
 				throw = false
 			end
-			
-			if throw then 
-				throwException("error", "MUST_HAVE_PROPERTY") 
+
+			if throw then
+				throwException("error", "MUST_HAVE_PROPERTY")
 			end
 		end
 	end
-	
+
 	local newObject
-	
+
 	-- Create the Point object
-	if object == "Point" then 
+	if object == "Point" then
 		local newPoint = Point.new(properties.Position or Vector2.new(), self.canvas, self, {
-			snap = properties.Snap, 
-			selectable = false, 
+			snap = properties.Snap,
+			selectable = false,
 			render = properties.Visible,
 			keepInCanvas = properties.KeepInCanvas or true
 		})
-		
+
 		-- Apply properties
 		if properties.Radius then newPoint:SetRadius(properties.Radius)	end
 		if properties.Color then newPoint:Stroke(properties.Color) end
@@ -282,112 +287,112 @@ function Engine:Create(object: string, properties: Types.Properties)
 		table.insert(self.points, newPoint)
 		newObject = newPoint
 	-- Create the constraint object
-	elseif object == "Constraint" then 
-		if not table.find(Globals.constraint.types, string.lower(properties.Type or "")) then 
-			throwException("error", "INVALID_CONSTRAINT_TYPE") 
+	elseif object == "Constraint" then
+		if not table.find(Globals.constraint.types, string.lower(properties.Type or "")) then
+			throwException("error", "INVALID_CONSTRAINT_TYPE")
 		end
-		
+
 		-- Validate restlength and thickness of the constraint
 		if properties.RestLength and properties.RestLength <= 0 then throwException("error", "INVALID_CONSTRAINT_LENGTH") end
 		if properties.Thickness and properties.Thickness <= 0 then throwException("error", "INVALID_CONSTRAINT_THICKNESS") end
-		
-		if properties.Point1 and properties.Point2 and properties.Type then 
+
+		if properties.Point1 and properties.Point2 and properties.Type then
 			-- Calculate distance
 			local dist = (properties.Point1.pos - properties.Point2.pos).Magnitude
 
 			local newConstraint = Constraint.new(properties.Point1, properties.Point2, self.canvas, {
-				restLength = properties.RestLength or dist, 
-				render = properties.Visible, 
+				restLength = properties.RestLength or dist,
+				render = properties.Visible,
 				thickness = properties.Thickness,
 				support = false,
 				TYPE = string.upper(properties.Type)
 			}, self)
-			
+
 			-- Apply properties
 			if properties.SpringConstant then newConstraint:SetSpringConstant(properties.SpringConstant) end
 			if properties.Color then newConstraint:Stroke(properties.Color) end
 
-			table.insert(self.constraints, newConstraint)	
+			table.insert(self.constraints, newConstraint)
 			newObject = newConstraint
 		end
 	-- Create the RigidBody object
 	elseif object == "RigidBody" then
 		-- Validate custom RigidBody structure
 
-		if properties.Object and not properties.Object:IsA("GuiObject") and not properties.Structure then 
-			error("'Object' must be a GuiObject", 2)	
+		if properties.Object and not properties.Object:IsA("GuiObject") and not properties.Structure then
+			error("'Object' must be a GuiObject", 2)
 		end
-		
+
 		local obj = nil
-		if not properties.Structure then 
+		if not properties.Structure then
 			obj = properties.Object
-		end 
-		
+		end
+
 		local custom: Types.Custom = {
 			Vertices = {},
 			Edges = {}
 		}
-		
-		if properties.Structure then 
-			if not self.canvas.frame then 
+
+		if properties.Structure then
+			if not self.canvas.frame then
 				throwException("error", "CANVAS_FRAME_NOT_FOUND")
 			end
 
-			for _, c in ipairs(properties.Structure) do 
+			for _, c in ipairs(properties.Structure) do
 				local a = c[1]
 				local b = c[2]
 				local support = c[3]
-				
-				if typeof(a) ~= "Vector2" or typeof(b) ~= "Vector2" then 
+
+				if typeof(a) ~= "Vector2" or typeof(b) ~= "Vector2" then
 					error("[Nature2D]: Invalid point positions for custom RigidBody structure.", 2)
 				end
-				
+
 				if support and typeof(support) ~= "boolean" then error("[Nature2D]: 'support' must be a boolean or nil") end
 				if a == b then error("[Nature2D]: A constraint cannot have the same points.", 2) end
-				
+
 				local PointA = SearchTable(custom.Vertices, a, function(i, v) return i == v.pos end)
 				local PointB = SearchTable(custom.Vertices, b, function(i, v) return i == v.pos end)
-				
-				if not PointA then 
-					PointA = Point.new(a, self.canvas, self, { 
-						snap = properties.Anchored, 
-						selectable = false, 
+
+				if not PointA then
+					PointA = Point.new(a, self.canvas, self, {
+						snap = properties.Anchored,
+						selectable = false,
 						render = false,
-						keepInCanvas = properties.KeepInCanvas or true 
+						keepInCanvas = properties.KeepInCanvas or true
 					})
 					table.insert(custom.Vertices, PointA)
 				end
-				
-				if not PointB then 
-					PointB = Point.new(b, self.canvas, self, { 
-						snap = properties.Anchored, 
-						selectable = false, 
+
+				if not PointB then
+					PointB = Point.new(b, self.canvas, self, {
+						snap = properties.Anchored,
+						selectable = false,
 						render = false,
-						keepInCanvas = properties.KeepInCanvas or true 
+						keepInCanvas = properties.KeepInCanvas or true
 					})
 					table.insert(custom.Vertices, PointB)
 				end
-				
+
 				local edge = Constraint.new(PointA, PointB, self.canvas, {
-					render = support and false or true, 
+					render = support and false or true,
 					thickness = 2,
 					support = support,
 					TYPE = "ROD"
 				}, self)
-				
+
 				table.insert(custom.Edges, edge)
 			end
 		end
-				
+
 		local newBody = RigidBody.new(
-			obj, 
-			properties.Mass or Globals.universalMass, 
-			properties.Collidable, 
-			properties.Anchored, 
+			obj,
+			properties.Mass or Globals.universalMass,
+			properties.Collidable,
+			properties.Anchored,
 			self,
 			properties.Structure and custom or nil
 		)
-		
+
 		--Apply properties
 		if properties.LifeSpan then newBody:SetLifeSpan(properties.LifeSpan) end
 		if typeof(properties.KeepInCanvas) == "boolean" then newBody:KeepInCanvas(properties.KeepInCanvas) end
@@ -397,25 +402,25 @@ function Engine:Create(object: string, properties: Types.Properties)
 
 		table.insert(self.bodies, newBody)
 		newObject = newBody
-	end	
-	
+	end
+
 	self.ObjectAdded:Fire(newObject)
 	return newObject
 end
 
--- This method is used to fetch all RigidBodies that have been created. 
+-- This method is used to fetch all RigidBodies that have been created.
 -- Ones that have been destroyed, won't be fetched.
 function Engine:GetBodies()
 	return self.bodies
 end
 
--- This method is used to fetch all Constraints that have been created. 
+-- This method is used to fetch all Constraints that have been created.
 -- Ones that have been destroyed, won't be fetched.
 function Engine:GetConstraints()
 	return self.constraints
 end
 
--- This method is used to fetch all Points that have been created. 
+-- This method is used to fetch all Points that have been created.
 function Engine:GetPoints()
 	return self.points
 end
@@ -429,49 +434,49 @@ function Engine:CreateCanvas(topLeft: Vector2, size: Vector2, frame: Frame)
 	self.canvas.topLeft = topLeft
 	self.canvas.size = size
 
-	if frame and frame:IsA("Frame") then 
+	if frame and frame:IsA("Frame") then
 		self.canvas.frame = frame
 	end
 end
 
--- This method is used to determine the simulation speed of the engine. 
+-- This method is used to determine the simulation speed of the engine.
 -- By default the simulation speed is set to 55.
 function Engine:SetSimulationSpeed(speed: number)
 	throwTypeError("speed", speed, 1, "number")
 	self.speed = speed
 end
 
--- This method is used to configure universal physical properties possessed by all rigid bodies and constraints. 
+-- This method is used to configure universal physical properties possessed by all rigid bodies and constraints.
 function Engine:SetPhysicalProperty(property: string, value: Vector2 | number)
 	throwTypeError("property", property, 1, "string")
 
 	local properties = Globals.properties
-	
+
 	-- Update properties of the Engine
 	local function Update(object)
-		if string.lower(property) == "collisionmultiplier" then 
+		if string.lower(property) == "collisionmultiplier" then
 			throwTypeError("value", value, 2, "number")
 			object.bounce = value
-		elseif string.lower(property) == "gravity" then 
+		elseif string.lower(property) == "gravity" then
 			throwTypeError("value", value, 2, "Vector2")
 			object.gravity = value
-		elseif string.lower(property) == "friction" then 					
+		elseif string.lower(property) == "friction" then
 			throwTypeError("value", value, 2, "number")
 			object.friction = math.clamp(1 - value, 0, 1)
-		elseif string.lower(property) == "airfriction" then 
+		elseif string.lower(property) == "airfriction" then
 			throwTypeError("value", value, 2, "number")
 			object.airfriction = math.clamp(1 - value, 0, 1)
 		end
 	end
-	
+
 	-- Validate and update properties
-	if table.find(properties, string.lower(property)) then 
-		if #self.bodies < 1 then 
+	if table.find(properties, string.lower(property)) then
+		if #self.bodies < 1 then
 			Update(self)
-		else 
+		else
 			Update(self)
-			for _, b in ipairs(self.bodies) do 
-				for _, v in ipairs(b:GetVertices()) do 
+			for _, b in ipairs(self.bodies) do
+				for _, v in ipairs(b:GetVertices()) do
 					Update(v)
 				end
 			end
@@ -485,8 +490,8 @@ end
 function Engine:GetBodyById(id: string)
 	throwTypeError("id", id, 1, "string")
 
-	for _, b in ipairs(self.bodies) do 
-		if b.id == id then 
+	for _, b in ipairs(self.bodies) do
+		if b.id == id then
 			return b
 		end
 	end
@@ -494,17 +499,17 @@ function Engine:GetBodyById(id: string)
 	return
 end
 
--- This method is used to fetch an individual constraint body from its ID. 
+-- This method is used to fetch an individual constraint body from its ID.
 function Engine:GetConstraintById(id: string)
 	throwTypeError("id", id, 1, "string")
 
-	for _, c in ipairs(self.constraints) do 
-		if c.id == id then 
+	for _, c in ipairs(self.constraints) do
+		if c.id == id then
 			return c
 		end
 	end
 
-	return 
+	return
 end
 
 ---- Returns current canvas the engine adheres to.
@@ -514,7 +519,7 @@ end
 
 function Engine:GetDebugInfo() : Types.DebugInfo
 	return {
-		Objects = { 
+		Objects = {
 			RigidBodies = #self.bodies,
 			Constraints = #self.constraints,
 			Points = #self.points
@@ -546,7 +551,7 @@ function Engine:UseQuadtrees(use: boolean)
 	self.quadtrees = use
 end
 
--- Determines if Frame rate does not affect the simulation speed. 
+-- Determines if Frame rate does not affect the simulation speed.
 -- By default set to true.
 function Engine:FrameRateIndependent(independent: boolean)
 	throwTypeError("independent", independent, 1, "boolean")

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -33,10 +33,10 @@ local function CollisionResponse(body: Types.RigidBody, other: Types.RigidBody, 
 	if not isColliding then return end
 
 	-- Fire the touched event
-	if body.Touched._handlerListHead and body.Touched._handlerListHead.Connected then 
+	if body.Touched._handlerListHead and body.Touched._handlerListHead.Connected then
 		if not SearchTable(oldCollidingWith, other, function(a, b) return a.id == b.id end) then
 			body.Touched:Fire(other.id)
-		end		
+		end
 	end
 
 	-- Calculate penetration in 2 dimensions
@@ -175,7 +175,7 @@ function Engine:Start()
 							other.Collisions.Body = false
 
 							-- Fire TouchEnded event
-							
+
 							if body.TouchEnded._handlerListHead and body.TouchEnded._handlerListHead.Connected then
 								if SearchTable(OldCollidingWith, other, function (a, b) return a.id == b.id end) then
 									body.TouchEnded:Fire(other.id)

--- a/src/Engine.lua
+++ b/src/Engine.lua
@@ -33,8 +33,10 @@ local function CollisionResponse(body: Types.RigidBody, other: Types.RigidBody, 
 	if not isColliding then return end
 
 	-- Fire the touched event
-	if not SearchTable(oldCollidingWith, other, function(a, b) return a.id == b.id end) then
-		body.Touched:Fire(other.id)
+	if body.Touched._handlerListHead and body.Touched._handlerListHead.Connected then 
+		if not SearchTable(oldCollidingWith, other, function(a, b) return a.id == b.id end) then
+			body.Touched:Fire(other.id)
+		end		
 	end
 
 	-- Calculate penetration in 2 dimensions
@@ -173,9 +175,11 @@ function Engine:Start()
 							other.Collisions.Body = false
 
 							-- Fire TouchEnded event
-
-							if SearchTable(OldCollidingWith, other, function (a, b) return a.id == b.id end) then
-								body.TouchEnded:Fire(other.id)
+							
+							if body.TouchEnded._handlerListHead and body.TouchEnded._handlerListHead.Connected then
+								if SearchTable(OldCollidingWith, other, function (a, b) return a.id == b.id end) then
+									body.TouchEnded:Fire(other.id)
+								end
 							end
 						end
 
@@ -185,8 +189,8 @@ function Engine:Start()
 			end
 
 			body.Collisions.Other = CollidingWith
-        
-      -- Render and Update of the body
+
+			-- Render and Update of the body
 			body:Update(dt)
 			body:Render()
 		end
@@ -286,7 +290,7 @@ function Engine:Create(object: string, properties: Types.Properties)
 
 		table.insert(self.points, newPoint)
 		newObject = newPoint
-	-- Create the constraint object
+		-- Create the constraint object
 	elseif object == "Constraint" then
 		if not table.find(Globals.constraint.types, string.lower(properties.Type or "")) then
 			throwException("error", "INVALID_CONSTRAINT_TYPE")
@@ -315,7 +319,7 @@ function Engine:Create(object: string, properties: Types.Properties)
 			table.insert(self.constraints, newConstraint)
 			newObject = newConstraint
 		end
-	-- Create the RigidBody object
+		-- Create the RigidBody object
 	elseif object == "RigidBody" then
 		-- Validate custom RigidBody structure
 

--- a/src/Physics/Constraint.lua
+++ b/src/Physics/Constraint.lua
@@ -1,6 +1,6 @@
 -- Constraints keep two points together in place and maintain uniform distance between the two.
--- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library. 
--- Custom constraints such as Ropes, Rods, Bridges and chains can also be made. 
+-- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library.
+-- Custom constraints such as Ropes, Rods, Bridges and chains can also be made.
 -- Points of two rigid bodies can be connected with constraints, two individual points can also be connected with constraints to form Ropes etc.
 
 -- Services and utilities
@@ -38,21 +38,21 @@ end
 function Constraint:Constrain()
 	local cur = (self.point2.pos - self.point1.pos).Magnitude
 	local force
-	
+
 	-- Validate constraint types
-	if self._TYPE == "ROPE" then 
+	if self._TYPE == "ROPE" then
 		local restLength = self.restLength
-		if cur < self.thickness then 
+		if cur < self.thickness then
 			restLength = self.thickness
 		end
-		
-		if cur > self.restLength or self.restLength < self.thickness then 
+
+		if cur > self.restLength or self.restLength < self.thickness then
 			-- Solve rope constraint force
 			local offset = ((restLength - cur)/restLength)/2
-			force = self.point2.pos - self.point1.pos 
+			force = self.point2.pos - self.point1.pos
 			force *= offset
 		end
-	elseif self._TYPE == "ROD" then 
+	elseif self._TYPE == "ROD" then
 		-- Solve rod constraint force
 		local offset = self.restLength - cur
 		local dif = self.point2.pos - self.point1.pos
@@ -60,49 +60,49 @@ function Constraint:Constrain()
 		force = (dif * offset)/2
 	elseif self._TYPE == "SPRING" then
 		-- Solve spring constraint force
-		force = self.point2.pos - self.point1.pos 
+		force = self.point2.pos - self.point1.pos
 		local mag = force.Magnitude - self.restLength
 		force = force.Unit
 		force *= -1 * self.k * mag
 	else
 		return
 	end
-	
+
 	-- Apply forces to constraint's points
-	if force then 
+	if force then
 		if not self.point1.snap then self.point1.pos -= force end
-		if not self.point2.snap then self.point2.pos += force end		
+		if not self.point2.snap then self.point2.pos += force end
 	end
 end
 
 -- This method is used to update the position and appearance of the constraint on screen.
 function Constraint:Render()
 	if self.render and not self.support then
-		if not self.canvas.frame then 
+		if not self.canvas.frame then
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-		
+
 		local thickness = self.thickness or Globals.constraint.thickness
 		local color = self.color or Globals.constraint.color
 		local image = self._TYPE == "SPRING" and "rbxassetid://8404350124" or nil
-		
-		if not self.frame then 
+
+		if not self.frame then
 			self.frame = line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, nil, image)
 		end
-		
+
 		-- Draw constraint on screen
 		line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, self.frame, image)
 	end
 end
 
--- Used to set the minimum constrained distance between two points. 
+-- Used to set the minimum constrained distance between two points.
 -- By default, the initial distance between the two points.
 function Constraint:SetLength(newLength: number)
 	throwTypeError("length", newLength, 1, "number")
-	if newLength <= 0 then 
+	if newLength <= 0 then
 		throwException("error", "INVALID_CONSTRAINT_LENGTH")
 	end
-	
+
 	self.restLength = newLength
 end
 
@@ -111,28 +111,28 @@ function Constraint:GetLength() : number
 	return (self.point2.pos - self.point1.pos).Magnitude
 end
 
--- This method is used to change the color of a constraint. 
+-- This method is used to change the color of a constraint.
 -- By default a constraint's color is set to the default value of (WHITE) Color3.new(1, 1, 1).
 function Constraint:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method destroys the constraint. 
--- Its UI element is no longer rendered on screen and the constraint is removed from the engine. 
--- This is irreversible.	
+-- This method destroys the constraint.
+-- Its UI element is no longer rendered on screen and the constraint is removed from the engine.
+-- This is irreversible.
 function Constraint:Destroy()
-	if self.engine then 
-		if self.frame then 
+	if self.engine then
+		if self.frame then
 			self.frame:Destroy()
 		end
-		
-		for i, c in ipairs(self.engine.constraints) do 
-			if c.id == self.id then 
+
+		for i, c in ipairs(self.engine.constraints) do
+			if c.id == self.id then
 				table.remove(self.engine.constraints, i)
 			end
 		end
-		
+
 		self.engine.ObjectRemoved:Fire(self)
 	end
 end

--- a/src/Physics/Point.lua
+++ b/src/Physics/Point.lua
@@ -1,4 +1,4 @@
--- Points are what make the rigid bodies behave like real world entities. 
+-- Points are what make the rigid bodies behave like real world entities.
 -- Points are responsible for the movement of the RigidBodies and Constraints.
 
 -- Services and utilities
@@ -37,24 +37,24 @@ function Point.new(pos: Vector2, canvas: Types.Canvas, engine: Types.EngineConfi
 			force = Vector2.new()
 		}
 	}, Point)
-	
+
 	return self
 end
 
--- This method is used to apply a force to the Point. 
+-- This method is used to apply a force to the Point.
 function Point:ApplyForce(force: Vector2, t: number)
 	throwTypeError("force", force, 1, "Vector2")
 	self.forces += force
-		
-	if t then 
+
+	if t then
 		throwTypeError("time", t, 2, "number")
 		if t <= 0 then
 			throwException("error", "INVALID_TIME")
 		end
-		
+
 		self.timed.start = os.clock()
 		self.timed.t = t
-		self.timed.force = force 
+		self.timed.force = force
 	end
 end
 
@@ -62,9 +62,9 @@ end
 function Point:Update(dt: number)
 	if not self.snap then
 		self:ApplyForce(self.gravity)
-		
-		if self.timed.start then 
-			if os.clock() - self.timed.start < self.timed.t then 
+
+		if self.timed.start then
+			if os.clock() - self.timed.start < self.timed.t then
 				self:ApplyForce(self.timed.force)
 			else
 				self.timed.start = nil
@@ -72,42 +72,42 @@ function Point:Update(dt: number)
 				self.timed.force = Vector2.new()
 			end
 		end
-		
+
 		-- Calculate velocity
-		local velocity = self.pos 
+		local velocity = self.pos
 		velocity -= self.oldPos
-		if self.engine.independent then 
+		if self.engine.independent then
 			self.forces *= dt * self.engine.speed
 		end
-		velocity += self.forces 
-		
+		velocity += self.forces
+
 		local body = self.Parent
-		
+
 		-- Apply friction
-		if body and body.Parent then 
+		if body and body.Parent then
 			local mass = body.Parent.mass
-			
-			if mass then 
+
+			if mass then
 				self.forces /= mass
 			end
-			
-			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then 
-				velocity *= self.friction 
-			else 
+
+			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then
+				velocity *= self.friction
+			else
 				velocity *= self.airfriction
-			end			
-		else 
+			end
+		else
 			velocity *= self.friction
 		end
-		
+
 		-- clamp velocity
-		if self.maxForce then 
+		if self.maxForce then
 			velocity = Vector2.new(
 				math.clamp(velocity.X, -self.maxForce, self.maxForce),
 				math.clamp(velocity.Y, -self.maxForce, self.maxForce)
 			)
 		end
-		
+
 		-- Update point positions
 		self.oldPos = self.pos
 		self.pos += velocity
@@ -115,49 +115,49 @@ function Point:Update(dt: number)
 	end
 end
 
--- This method is used to keep the point in the engine's canvas. 
--- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly. 
+-- This method is used to keep the point in the engine's canvas.
+-- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly.
 function Point:KeepInCanvas()
 	-- vx = velocity.X
 	-- vy = velocity.Y
 	local vx = self.pos.x - self.oldPos.x
 	local vy = self.pos.y - self.oldPos.y
 
-	local width = self.canvas.size.x	
-	local height = self.canvas.size.y 
+	local width = self.canvas.size.x
+	local height = self.canvas.size.y
 
 	local collision = false
 	local edge
-	
+
 	if self.pos.y > height then
-		self.pos = Vector2.new(self.pos.x, height) 
+		self.pos = Vector2.new(self.pos.x, height)
 		self.oldPos = Vector2.new(self.oldPos.x, self.pos.y + vy * self.bounce)
 		collision = true
 		edge = "Bottom"
 	elseif self.pos.y < self.canvas.topLeft.y then
-		self.pos = Vector2.new(self.pos.x, self.canvas.topLeft.y) 
+		self.pos = Vector2.new(self.pos.x, self.canvas.topLeft.y)
 		self.oldPos = Vector2.new(self.oldPos.x, self.pos.y - vy * self.bounce)
 		collision = true
 		edge = "Top"
 	end
 
 	if self.pos.x < self.canvas.topLeft.x then
-		self.pos = Vector2.new(self.canvas.topLeft.x, self.pos.y) 
+		self.pos = Vector2.new(self.canvas.topLeft.x, self.pos.y)
 		self.oldPos = Vector2.new(self.pos.x + vx * self.bounce, self.oldPos.y)
 		collision = true
 		edge = "Left"
 	elseif self.pos.x > width then
-		self.pos = Vector2.new(width, self.pos.y) 
+		self.pos = Vector2.new(width, self.pos.y)
 		self.oldPos = Vector2.new(self.pos.x - vx * self.bounce, self.oldPos.y)
 		collision = true
 		edge = "Right"
 	end
-	
+
 	local body = self.Parent
-	
+
 	-- Fire CanvasEdgeTouched event
-	if body and body.Parent then 
-		if collision then 
+	if body and body.Parent then
+		if collision then
 			body.Parent.Collisions.CanvasEdge = true
 			body.Parent.CanvasEdgeTouched:Fire(edge)
 		else
@@ -168,17 +168,17 @@ end
 
 -- This method is used to update the position and appearance of the Point on screen.
 function Point:Render()
-	if self.render then 
-		if not self.canvas.frame then 
+	if self.render then
+		if not self.canvas.frame then
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-		
-		if not self.frame then 
+
+		if not self.frame then
 			-- Create new instance for the point
 			local p = Instance.new("Frame")
 			local border = Instance.new("UICorner")
 			local r = self.radius or Globals.point.radius
-			
+
 			p.AnchorPoint = Vector2.new(.5, .5)
 			p.BackgroundColor3 = self.color or Globals.point.color
 			p.Size = UDim2.new(0, r * 2, 0, r * 2)
@@ -189,12 +189,12 @@ function Point:Render()
 
 			self.frame = p
 		end
-		
+
 		-- Update the point's instance
 		self.frame.Position = UDim2.new(0, self.pos.x, 0, self.pos.y)
 	end
-	
-	if self.keepInCanvas then 
+
+	if self.keepInCanvas then
 		self:KeepInCanvas()
 	end
 end
@@ -205,14 +205,14 @@ function Point:SetRadius(radius: number)
 	self.radius = radius
 end
 
--- his method is used to determine the color of the point on screen. 
+-- his method is used to determine the color of the point on screen.
 -- By default this is set to (RED) Color3.new(1, 0, 0).
 function Point:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method determines if the point remains anchored. 
+-- This method determines if the point remains anchored.
 -- If set to false, the point is unanchored.
 function Point:Snap(snap: boolean)
 	throwTypeError("snap", snap, 1, "boolean")

--- a/src/Physics/RigidBody.lua
+++ b/src/Physics/RigidBody.lua
@@ -404,8 +404,10 @@ function RigidBody:Destroy(keepFrame: boolean)
 			-- Destroy the frame and remove the RigidBody from the Engine.
 			self.Touched:Destroy()
 			self.CanvasEdgeTouched:Destroy()
+			self.TouchEnded:Destroy()
 			self.Touched = nil
 			self.CanvasEdgeTouched = nil
+			self.TouchEnded = nil
 			if not self.custom and not keepFrame then
 				self.frame:Destroy()
 			end

--- a/src/Physics/RigidBody.lua
+++ b/src/Physics/RigidBody.lua
@@ -23,13 +23,13 @@ local function GetCorners(frame: GuiObject, engine)
 	local temp = math.sqrt((size.X/2)^2+(size.Y/2)^2)
 
 	local offset = (engine.path and engine.path.IgnoreGuiInset) and Globals.offset or Vector2.new(0, 0)
-	
+
 	-- Calculate and return all 4 corners of the GuiObject
 	-- Also adheres to the Rotation of the GuiObject
 	local t = math.atan2(size.Y, size.X)
 	local a = rotation + t
 	local b = rotation - t
-	
+
 	return {
 		center - temp * Vector2.new(math.cos(a), math.sin(a)) + offset, -- topleft
 		center + temp * Vector2.new(math.cos(b), math.sin(b)) + offset, -- topright
@@ -40,10 +40,10 @@ end
 
 -- This method is used to calculate the depth/penetration of a collision
 local function CalculatePenetration(minA: number, maxA: number, minB: number, maxB: number) : number
-	if minA < minB then 
-		return minB - maxA 
-	else 
-		return minA - maxB 
+	if minA < minB then
+		return minB - maxA
+	else
+		return minA - maxB
 	end
 end
 
@@ -60,7 +60,7 @@ local function CalculateCenter(vertices) : Vector2
 	local maxX = -math.huge
 	local maxY = -math.huge
 
-	for _, v in ipairs(vertices) do 
+	for _, v in ipairs(vertices) do
 		center += v.pos
 		minX = math.min(minX, v.pos.x)
 		minY = math.min(minY, v.pos.y)
@@ -80,7 +80,7 @@ local function CalculateSize(vertices)
 	local maxX = -math.huge
 	local maxY = -math.huge
 
-	for _, v in ipairs(vertices) do 
+	for _, v in ipairs(vertices) do
 		minX = math.min(minX, v.pos.x)
 		minY = math.min(minY, v.pos.y)
 		maxX = math.max(maxX, v.pos.x)
@@ -93,7 +93,7 @@ end
 -- This method is used to update the positions of each point of a rigidbody to the corners of a UI element.
 local function UpdateVertices(frame: GuiObject, vertices, engine)
 	local corners = GetCorners(frame, engine)
-	for i, vertex in ipairs(vertices) do 
+	for i, vertex in ipairs(vertices) do
 		vertex:SetPosition(corners[i].X, corners[i].Y)
 	end
 end
@@ -102,30 +102,30 @@ end
 -- This method is used to initialize a new RigidBody.
 function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, anchored: boolean?, engine, custom: Types.Custom?)
 	local isCustom = false
-	
-	if custom then 
+
+	if custom then
 		isCustom = true
 	end
-	
+
 	local vertices = isCustom and custom.Vertices or {}
 	local edges = isCustom and custom.Edges or {}
-	
+
 	-- Configurations
 	local pointConfig = {
-		snap = anchored, 
-		selectable = false, 
+		snap = anchored,
+		selectable = false,
 		render = false,
 		keepInCanvas = true
 	}
 
 	local constraintConfig = {
-		restLength = nil, 
-		render = false, 
+		restLength = nil,
+		render = false,
 		thickness = 4,
 		support = false,
 		TYPE = "ROD"
 	}
-	
+
 	-- Point creation method
 	local function addPoint(pos)
 		local newPoint = Point.new(pos, engine.canvas, engine, pointConfig)
@@ -133,7 +133,7 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 
 		return newPoint
 	end
-	
+
 	-- Constraint creation method
 	local function addConstraint(p1, p2, support)
 		constraintConfig.support = support
@@ -143,8 +143,8 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 
 		return newConstraint
 	end
-	
-	if not isCustom then 
+
+	if not isCustom then
 		-- Create Points
 		local corners = GetCorners(frame, engine)
 		local topleft = addPoint(corners[1])
@@ -158,8 +158,8 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 		addConstraint(topright, bottomright, false)
 		addConstraint(bottomleft, bottomright, false)
 		addConstraint(topleft, bottomright, true)
-		addConstraint(topright, bottomleft, true)    	
-	end           
+		addConstraint(topright, bottomleft, true)
+	end
 
 	local self = setmetatable({
 		id = HttpService:GenerateGUID(false),
@@ -180,7 +180,7 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 		Touched = nil,
 		TouchEnded = nil,
 		CanvasEdgeTouched = nil,
-		Collisions = {			
+		Collisions = {
 			Body = false,
 			CanvasEdge = false,
 			Other = {}
@@ -188,19 +188,19 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 		States = {},
 		filtered = {},
 	}, RigidBody)
-	
+
 	-- Apply offsets if ScreenGui's IgnoreGuiInset property is set to true
 	-- Offset = Vector2.new(0, 36)
-	if engine.path and engine.path.IgnoreGuiInset then 
+	if engine.path and engine.path.IgnoreGuiInset then
 		self.anchorPos = self.anchorPos and self.anchorPos + Globals.offset or nil
 		self.center += Globals.offset
 	end
-	
+
 	-- Create events
 	self.Touched = Signal.new()
 	self.TouchEnded = Signal.new()
 	self.CanvasEdgeTouched = Signal.new()
-	
+
 	-- Set parents of points and constraints
 	for _, edge in ipairs(edges) do
 		edge.point1.Parent = edge
@@ -227,13 +227,13 @@ end
 
 -- This method detects collision between two RigidBodies.
 function RigidBody:DetectCollision(other)
-	if not self.custom and (not self.frame and not other.frame) then 
+	if not self.custom and (not self.frame and not other.frame) then
 		return { false, {} }
 	end
-	
+
 	-- Calculate center of the Body
 	self.center = CalculateCenter(self.vertices)
-	
+
 	-- Initialize collision information
 	local minDist = math.huge
 	local collision: Types.Collision = {
@@ -242,7 +242,7 @@ function RigidBody:DetectCollision(other)
 		edge = nil,
 		vertex = nil
 	}
-	
+
 	-- Loop throught both bodies' edges (excluding support edges)
 	-- Calculate an axis and then project both bodies to the axis
 	-- Assign axis and edge of collision to the collision information dictionary
@@ -252,7 +252,7 @@ function RigidBody:DetectCollision(other)
 	for i = 1, #self.edges + #other.edges, 1 do
 		local edge = i <= #self.edges and self.edges[i] or other.edges[i - #self.edges]
 
-		if not edge.support then 
+		if not edge.support then
 			local axis = Vector2.new(
 				edge.point1.pos.Y - edge.point2.pos.Y,
 				edge.point2.pos.X - edge.point1.pos.X
@@ -264,13 +264,13 @@ function RigidBody:DetectCollision(other)
 
 			local dist = CalculatePenetration(MinA, MaxA, MinB, MaxB)
 
-			if dist > 0 then 
+			if dist > 0 then
 				return { false, {} }
 			elseif math.abs(dist) < minDist then
-				minDist = math.abs(dist) 
+				minDist = math.abs(dist)
 				collision.axis = axis
 				collision.edge = edge
-			end	
+			end
 		end
 	end
 
@@ -285,11 +285,11 @@ function RigidBody:DetectCollision(other)
 	local centerDif = self.center - other.center
 	local dot = collision.axis:Dot(centerDif)
 
-	if dot < 0 then 
+	if dot < 0 then
 		collision.axis *= -1
-	end	
+	end
 
-	local minMag = math.huge 
+	local minMag = math.huge
 
 	for i = 1, #self.vertices, 1 do
 		local dif =  self.vertices[i].pos - other.center
@@ -307,15 +307,15 @@ end
 -- This method is used to apply an external force on the rigid body.
 function RigidBody:ApplyForce(force: Vector2, t: number)
 	throwTypeError("force", force, 1, "Vector2")
-	
-	if t then 
+
+	if t then
 		throwTypeError("time", t, 2, "number")
-		if t <= 0 then 
+		if t <= 0 then
 			throwException("error", "INVALID_TIME")
 		end
 	end
-	
-	for _, v in ipairs(self.vertices) do 
+
+	for _, v in ipairs(self.vertices) do
 		v:ApplyForce(force, t)
 	end
 end
@@ -323,33 +323,33 @@ end
 -- This method updates the positions of the RigidBody's points and constraints.
 function RigidBody:Update(dt: number)
 	self.center = CalculateCenter(self.vertices)
-	
+
 	-- Update vertices and edges together
-	for i = 1, #self.vertices + #self.edges do 
+	for i = 1, #self.vertices + #self.edges do
 		local edge = i > #self.vertices
 
-		if edge then 
+		if edge then
 			local e = self.edges[(#self.vertices + #self.edges) + 1 - i]
 			e:Constrain()
-			if self.custom then 
+			if self.custom then
 				e:Render()
 			end
-		else 
+		else
 			self.vertices[i]:Update(dt)
 			self.vertices[i]:Render()
 		end
-	end	
+	end
 end
 
 -- This method updates the positions and appearance of the RigidBody on screen.
 function RigidBody:Render()
 	-- If the RigidBody exceeds its life span, it is destroyed.
-	if self.lifeSpan and os.clock() - self.spawnedAt >= self.lifeSpan then 
+	if self.lifeSpan and os.clock() - self.spawnedAt >= self.lifeSpan then
 		self:Destroy()
 	end
-	
+
 	if self.custom then return end
-	
+
 	-- Apply rotations and update positions
 	-- Respects the anchor point of the GuiObject
 
@@ -357,7 +357,7 @@ function RigidBody:Render()
 		local anchorPos = self.anchorPos - CalculateOffset(self.anchorPos, self.frame.AnchorPoint, self.frame.AbsoluteSize)
 		self.frame.Position = UDim2.fromOffset(anchorPos.X, anchorPos.Y)
 		self:Rotate(self.anchorRotation)
-	else 
+	else
 		local center = self.center - CalculateOffset(self.center, self.frame.AnchorPoint, self.frame.AbsoluteSize)
 		local dif: Vector2 = self.vertices[2].pos - self.vertices[1].pos
 
@@ -370,32 +370,32 @@ end
 function RigidBody:Clone(deepCopy: boolean)
 	restrict(self.custom)
 	if not self.frame then return end
-	
+
 	local frame = self.frame:Clone()
 	frame.Parent = self.frame.Parent
-	
+
 	local copy = RigidBody.new(frame, self.mass, self.collidable, self.anchored, self.engine)
-	
+
 	-- Copy lifespan, states and filtered RigidBodies
-	if deepCopy == true then 
+	if deepCopy == true then
 		copy.States = self.States
-		
-		if self.lifeSpan then 
+
+		if self.lifeSpan then
 			copy:SetLifeSpan(self.lifeSpan)
 		end
-		
+
 		for _, body in ipairs(self.filtered) do
 			copy:FilterCollisionsWith(body)
 		end
 	end
-	
+
 	table.insert(self.engine.bodies, copy)
 	self.engine.ObjectAdded:Fire(copy)
-	
+
 	return copy
 end
 
--- This method is used to destroy the RigidBody. 
+-- This method is used to destroy the RigidBody.
 -- The body's UI element is destroyed, its connections are disconnected and the body is removed from the engine.
 function RigidBody:Destroy(keepFrame: boolean)
 	for i, body in ipairs(self.engine.bodies) do
@@ -404,14 +404,14 @@ function RigidBody:Destroy(keepFrame: boolean)
 			-- Destroy the frame and remove the RigidBody from the Engine.
 			self.Touched:Destroy()
 			self.CanvasEdgeTouched:Destroy()
-			self.Touched = nil 
+			self.Touched = nil
 			self.CanvasEdgeTouched = nil
-			if not self.custom and not keepFrame then 
+			if not self.custom and not keepFrame then
 				self.frame:Destroy()
 			end
-			if self.custom and not keepFrame then 
-				for _, c in ipairs(self.edges) do 
-					if c.frame then 
+			if self.custom and not keepFrame then
+				for _, c in ipairs(self.edges) do
+					if c.frame then
 						c.frame:Destroy()
 					end
 				end
@@ -424,17 +424,17 @@ function RigidBody:Destroy(keepFrame: boolean)
 	end
 end
 
--- This method is used to rotate the RigidBody's UI element. 
+-- This method is used to rotate the RigidBody's UI element.
 -- After rotation the positions of its points and constraints are automatically updated.
 function RigidBody:Rotate(newRotation: number)
 	restrict(self.custom)
 	throwTypeError("newRotation", newRotation, 1, "number")
-	
+
 	-- Update anchorRotation if the body is anchored
-	if self.anchored and self.anchorRotation then 
+	if self.anchored and self.anchorRotation then
 		self.anchorRotation = newRotation
 	end
-	
+
 	-- Apply rotation and update positions
 	-- Update the RigidBody's points
 	local oldRotation = self.frame.Rotation
@@ -452,12 +452,12 @@ function RigidBody:SetPosition(PositionX: number, PositionY: number)
 	restrict(self.custom)
 	throwTypeError("PositionX", PositionX, 1, "number")
 	throwTypeError("PositionY", PositionY, 2, "number")
-	
+
 	-- Update anchorPos if the body is anchored
-	if self.anchored and self.anchorPos then 
+	if self.anchored and self.anchorPos then
 		self.anchorPos = Vector2.new(PositionX, PositionY)
 	end
-	
+
 	-- Update position
 	-- Update the RigidBody's points
 	local oldPosition = self.frame.Position
@@ -467,12 +467,12 @@ function RigidBody:SetPosition(PositionX: number, PositionY: number)
 	return oldPosition, UDim2.fromOffset(PositionX, PositionY)
 end
 
--- This method is used to set a new size of the RigidBody's UI element. 
+-- This method is used to set a new size of the RigidBody's UI element.
 function RigidBody:SetSize(SizeX: number, SizeY: number)
 	restrict(self.custom)
 	throwTypeError("SizeX", SizeX, 1, "number")
-	throwTypeError("SizeY", SizeY, 2, "number")	
-	
+	throwTypeError("SizeY", SizeY, 2, "number")
+
 	-- Update size
 	-- Update the RigidBody's points
 	local oldSize = self.frame.Size
@@ -505,7 +505,7 @@ function RigidBody:Unanchor()
 	end
 end
 
--- This method is used to determine whether the RigidBody will collide with other RigidBodies. 
+-- This method is used to determine whether the RigidBody will collide with other RigidBodies.
 function RigidBody:CanCollide(collidable: boolean)
 	throwTypeError("collidable", collidable, 1, "boolean")
 	self.collidable = collidable
@@ -531,7 +531,7 @@ function RigidBody:GetConstraints()
 	return self.edges
 end
 
---vThis method is used to set the RigidBody's life span. 
+--vThis method is used to set the RigidBody's life span.
 -- Life span is determined by 'seconds'.
 -- After this time in seconds has been passed after the RigidBody is created, the RigidBody is automatically destroyed and removed from the engine.
 function RigidBody:SetLifeSpan(seconds: number)
@@ -539,11 +539,11 @@ function RigidBody:SetLifeSpan(seconds: number)
 	self.lifeSpan = seconds
 end
 
--- This method determines if the RigidBody stays inside the engine's canvas at all times. 
+-- This method determines if the RigidBody stays inside the engine's canvas at all times.
 function RigidBody:KeepInCanvas(keepInCanvas: boolean)
 	throwTypeError("keepInCanvas", keepInCanvas, 1, "boolean")
 
-	for _, p in ipairs(self.vertices) do 
+	for _, p in ipairs(self.vertices) do
 		p.keepInCanvas = keepInCanvas
 	end
 end
@@ -577,7 +577,7 @@ end
 
 -- Sets a new mass for the RigidBody
 function RigidBody:SetMass(mass: number)
-	if self.mass ~= mass and mass >= 1 then 
+	if self.mass ~= mass and mass >= 1 then
 		self.mass = mass
 	end
 end
@@ -586,27 +586,27 @@ end
 function RigidBody:IsInBounds() : boolean
 	local canvas = self.engine.canvas
 	if not canvas then return false end
-	
+
 	-- Check if all vertices lie within the canvas.
-	for _, v in ipairs(self.vertices) do 
-		local pos = v.pos 
-	
-		if not ((pos.X >= canvas.topLeft.X and pos.X <= canvas.topLeft.X + canvas.size.X) and (pos.Y >= canvas.topLeft.Y and pos.Y <= canvas.topLeft.Y + canvas.size.Y)) then 
+	for _, v in ipairs(self.vertices) do
+		local pos = v.pos
+
+		if not ((pos.X >= canvas.topLeft.X and pos.X <= canvas.topLeft.X + canvas.size.X) and (pos.Y >= canvas.topLeft.Y and pos.Y <= canvas.topLeft.Y + canvas.size.Y)) then
 			return false
 		end
 	end
-	
+
 	return true
 end
 
 -- Returns the average of all the velocities of the RigidBody's points
 function RigidBody:AverageVelocity() : Vector2
 	local sum = Vector2.new(0, 0)
-	
+
 	for _, v in ipairs(self.vertices) do
 		sum += v:Velocity()
 	end
-	
+
 	-- Return average
 	return sum/#self.vertices
 end
@@ -632,34 +632,34 @@ function RigidBody:GetCenter()
 end
 
 -- Used to ignore/filter any collisions with the other RigidBody.
-function RigidBody:FilterCollisionsWith(otherBody)	
-	if not otherBody.id or not typeof(otherBody.id) == "string" or not otherBody.filtered then 
+function RigidBody:FilterCollisionsWith(otherBody)
+	if not otherBody.id or not typeof(otherBody.id) == "string" or not otherBody.filtered then
 		throwException("error", "INVALID_RIGIDBODY")
 	end
-	
+
 	if otherBody.id == self.id then throwException("error", "SAME_ID") end
 
 	-- Insert the ids into their respective places
-	if not table.find(self.filtered, otherBody.id) then 
+	if not table.find(self.filtered, otherBody.id) then
 		table.insert(self.filtered, otherBody.id)
 		table.insert(otherBody.filtered, self.id)
 	end
 end
 
--- Used to unfilter collisions with the other RigidBody. 
+-- Used to unfilter collisions with the other RigidBody.
 -- The two bodies will now collide with each other.
 function RigidBody:UnfilterCollisionsWith(otherBody)
-	if not otherBody.id or not typeof(otherBody.id) == "string" or not otherBody.filtered then 
+	if not otherBody.id or not typeof(otherBody.id) == "string" or not otherBody.filtered then
 		throwException("error", "INVALID_RIGIDBODY")
 	end
 
 	if otherBody.id == self.id then throwException("error", "SAME_ID") end
-	
+
 	local i1 = table.find(self.filtered, otherBody.id)
 	local i2 = table.find(otherBody.filtered, self.id)
-	
+
 	-- Remove the ids from their respective places
-	if i1 and i2 then 
+	if i1 and i2 then
 		table.remove(self.filtered, i1)
 		table.remove(otherBody.filtered, i2)
 	end
@@ -678,7 +678,7 @@ end
 -- Determines the max force that can be aoplied to the RigidBody.
 function RigidBody:SetMaxForce(maxForce: number)
 	throwTypeError("maxForce", maxForce, 1, "number")
-	for _, p in ipairs(self.vertices) do 
+	for _, p in ipairs(self.vertices) do
 		p:SetMaxForce(maxForce)
 	end
 end

--- a/src/Physics/RigidBody.lua
+++ b/src/Physics/RigidBody.lua
@@ -329,9 +329,14 @@ function RigidBody:Update(dt: number)
 		local edge = i > #self.vertices
 
 		if edge then 
-			self.edges[(#self.vertices + #self.edges) + 1 - i]:Constrain()
+			local e = self.edges[(#self.vertices + #self.edges) + 1 - i]
+			e:Constrain()
+			if self.custom then 
+				e:Render()
+			end
 		else 
 			self.vertices[i]:Update(dt)
+			self.vertices[i]:Render()
 		end
 	end	
 end

--- a/src/Plugins/MouseConstraint.lua
+++ b/src/Plugins/MouseConstraint.lua
@@ -9,14 +9,14 @@ return function (engine: { any }, range: number)
 	})
 	local held = nil
 	local constraint = nil
-	
+
 	UserInputService.InputBegan:Connect(function(input, processedEvent)
 		if processedEvent then return end
-		
-		if input.UserInputType == Enum.UserInputType.MouseButton1 and not held and not constraint then 
-			for _, b in ipairs(engine.bodies) do 
-				for _, p in ipairs(b.vertices) do 
-					if (p.pos - UserInputService:GetMouseLocation()).Magnitude <= range then 
+
+		if input.UserInputType == Enum.UserInputType.MouseButton1 and not held and not constraint then
+			for _, b in ipairs(engine.bodies) do
+				for _, p in ipairs(b.vertices) do
+					if (p.pos - UserInputService:GetMouseLocation()).Magnitude <= range then
 						p.selectable = true
 						held = p
 						constraint = engine:Create("Constraint", {
@@ -25,28 +25,28 @@ return function (engine: { any }, range: number)
 							Point2 = mousePoint,
 							RestLength = 1,
 							Visible = false
-						})			
+						})
 						break
 					end
 				end
 			end
 		end
 	end)
-	
+
 	UserInputService.InputEnded:Connect(function(input, processedEvent)
 		if processedEvent then return end
-		
-		if input.UserInputType == Enum.UserInputType.MouseButton1 and held and constraint then 
+
+		if input.UserInputType == Enum.UserInputType.MouseButton1 and held and constraint then
 			held.selectable = false
 			constraint:Destroy()
 			held = nil
 			constraint = nil
 		end
 	end)
-	
+
 	UserInputService.InputChanged:Connect(function(input, processedEvent)
 		if processedEvent then return end
-		
+
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
 			local mouse = UserInputService:GetMouseLocation()
 			mousePoint:SetPosition(mouse.X, mouse.Y)

--- a/src/Plugins/Quad.lua
+++ b/src/Plugins/Quad.lua
@@ -1,11 +1,11 @@
 -- Returns a quadrilateral structure for Custom RigidBodies given 4 points
 return function (a: Vector2, b: Vector2, c: Vector2, d: Vector2)
 	return {
-		{ a, b, false }, 
-		{ b, c, false }, 
-		{ c, d, false }, 
-		{ d, a, false }, 
-		{ a, c, true }, 
+		{ a, b, false },
+		{ b, c, false },
+		{ c, d, false },
+		{ d, a, false },
+		{ a, c, true },
 		{ b, d, true }
 	}
 end

--- a/src/Plugins/Triangle.lua
+++ b/src/Plugins/Triangle.lua
@@ -1,8 +1,8 @@
 -- Returns a triangular structure for Custom RigidBodies given 3 points
 return function (a: Vector2, b: Vector2, c: Vector2)
 	return {
-		{ a, b, false }, 
-		{ a, c, false }, 
+		{ a, b, false },
+		{ a, c, false },
 		{ b, c, false }
 	}
 end

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -57,8 +57,8 @@ export type RigidBody = {
 }
 
 export type SegmentConfig = {
-	restLength: number?, 
-	render: boolean, 
+	restLength: number?,
+	render: boolean,
 	thickness: number?,
 	support: boolean,
 	TYPE: string,
@@ -73,8 +73,8 @@ export type EngineConfig = {
 }
 
 export type PointConfig = {
-	snap: boolean, 
-	selectable: boolean, 
+	snap: boolean,
+	selectable: boolean,
 	render: boolean,
 	keepInCanvas: boolean
 }
@@ -101,11 +101,11 @@ export type Properties = {
 	Type: string?,
 	Point1: Point?,
 	Point2: Point?,
-	Thickness: number?, 
+	Thickness: number?,
 	RestLength: number?,
 	SpringConstant: number?,
-	Object: GuiObject?, 
-	Collidable: boolean?, 
+	Object: GuiObject?,
+	Collidable: boolean?,
 	Anchored: boolean?,
 	LifeSpan: number?,
 	Gravity: Vector2?,
@@ -128,7 +128,7 @@ export type Plugins = {
 }
 
 export type DebugInfo = {
-	Objects: { 
+	Objects: {
 		RigidBodies: number,
 		Constraints: number,
 		Points: number

--- a/src/Utilities/Line.lua
+++ b/src/Utilities/Line.lua
@@ -14,15 +14,15 @@ local function draw(hyp: number, origin: Vector2, thickness: number, parent: Ins
 	line.Position = UDim2.fromOffset(origin.X, origin.Y)
 	line.ZIndex = 1
 
-	if image then 
+	if image then
 		line.Image = image
 		line.ImageColor3 = color or Globals.constraint.color
-	else 
+	else
 		line.BackgroundColor3 = color or Globals.constraint.color
 	end
 
 	line.Parent = parent
-	
+
 	return line
 end
 
@@ -33,8 +33,8 @@ return function (origin: Vector2, endpoint: Vector2, parent: Instance, thickness
 	local hyp = (endpoint - origin).Magnitude
 	local line = draw(hyp, origin, thickness, parent, color, l, image)
 	local mid = (origin + endpoint)/2
-	local theta = math.atan2((origin - endpoint).Y, (origin - endpoint).X)	
-	
+	local theta = math.atan2((origin - endpoint).Y, (origin - endpoint).X)
+
 	-- Apply rotation and update position
 	line.Position = UDim2.fromOffset(mid.x, mid.y)
 	line.Rotation = math.deg(theta)

--- a/src/Utilities/Quadtree.lua
+++ b/src/Utilities/Quadtree.lua
@@ -12,8 +12,8 @@ local function GetDivisions(position: Vector2, size: Vector2)
 	return {
 		position,
 		position + Vector2.new(size.X/2, 0),
-		position + Vector2.new(0, size.Y/2), 
-		position + Vector2.new(size.X/2, size.Y/2), 
+		position + Vector2.new(0, size.Y/2),
+		position + Vector2.new(size.X/2, size.Y/2),
 	}
 end
 
@@ -26,27 +26,27 @@ local function RangeOverlapsNode(node: Types.Quadtree<Types.RigidBody>, range: T
 	local ap2 = node.position
 	local as2 = node.size
 	local sum2 = ap2 + as2
-	
+
 	-- Detect overlapping
 	return (ap1.x < sum2.x and sum.x > ap2.x) and (ap1.y < sum2.y and sum.y > ap2.y)
 end
 
 -- Check if a point lies within a range
 local function RangeHasPoint(range: Types.Range, obj: Types.RigidBody) : boolean
-	local p = obj.center 
+	local p = obj.center
 
 	return (
-		(p.X > range.position.X) and (p.X < (range.position.X + range.size.X)) and 
+		(p.X > range.position.X) and (p.X < (range.position.X + range.size.X)) and
 		(p.Y > range.position.Y) and (p.Y < (range.position.Y + range.size.Y))
 	)
 end
 
 -- Merge two arrays
 local function merge<T>(array1: {T}, array2: {T}) : {T}
-	if #array2 > 0 then 
+	if #array2 > 0 then
 		for _, v in ipairs(array2) do
 			table.insert(array1, v)
-		end		
+		end
 	end
 
 	return array1
@@ -66,16 +66,16 @@ end
 -- Insert a RigidBody in the quadtree
 function Quadtree:Insert(body: Types.RigidBody)
 	if not self:HasObject(body.center) then return end
-		
-	if #self.objects < self.capacity then 
+
+	if #self.objects < self.capacity then
 		self.objects[#self.objects + 1] = body
 	else
 		-- Subdivide if not already
-		if not self.divided then 
+		if not self.divided then
 			self:SubDivide()
 			self.divided = true
 		end
-		
+
 		-- Insert the RigidBody in the subdivisions if possible
 		self.topLeft:Insert(body)
 		self.topRight:Insert(body)
@@ -86,7 +86,7 @@ end
 
 function Quadtree:HasObject(p: Vector2) : boolean
 	return (
-		(p.X > self.position.X) and (p.X < (self.position.X + self.size.X)) and 
+		(p.X > self.position.X) and (p.X < (self.position.X + self.size.X)) and
 		(p.Y > self.position.Y) and (p.Y < (self.position.Y + self.size.Y))
 	)
 end
@@ -101,14 +101,14 @@ function Quadtree:SubDivide()
 	self.bottomRight = Quadtree.new(divisions[4], self.size/2, self.capacity)
 end
 
--- Search through the nodes, given a range query. 
+-- Search through the nodes, given a range query.
 -- Returns any rigidbody that lies within the range.
 function Quadtree:Search(range: Types.Range, objects: { Types.RigidBody })
-	if not objects then 
+	if not objects then
 		objects = {}
 	end
 
-	if not RangeOverlapsNode(self, range) then 
+	if not RangeOverlapsNode(self, range) then
 		return objects
 	end
 

--- a/src/Utilities/Signal.lua
+++ b/src/Utilities/Signal.lua
@@ -94,7 +94,7 @@ Connection.Destroy = Connection.Disconnect
 -- Make Connection strict
 setmetatable(Connection, {
 	__index = function(_tb, key)
-		if key ~= "_handlerListHead" then 
+		if key ~= "_handlerListHead" then
 			error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
 		end
 	end,
@@ -273,7 +273,7 @@ end
 -- Make signal strict
 setmetatable(Signal, {
 	__index = function(_tb, key)
-		if key ~= "Connected" then 
+		if key ~= "Connected" then
 			error(("Attempt to get Signal::%s (not a valid member)"):format(tostring(key)), 2)
 		end
 	end,

--- a/src/Utilities/Signal.lua
+++ b/src/Utilities/Signal.lua
@@ -94,7 +94,9 @@ Connection.Destroy = Connection.Disconnect
 -- Make Connection strict
 setmetatable(Connection, {
 	__index = function(_tb, key)
-		error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
+		if key ~= "_handlerListHead" then 
+			error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
+		end
 	end,
 	__newindex = function(_tb, key, _value)
 		error(("Attempt to set Connection::%s (not a valid member)"):format(tostring(key)), 2)
@@ -271,7 +273,9 @@ end
 -- Make signal strict
 setmetatable(Signal, {
 	__index = function(_tb, key)
-		error(("Attempt to get Signal::%s (not a valid member)"):format(tostring(key)), 2)
+		if key ~= "Connected" then 
+			error(("Attempt to get Signal::%s (not a valid member)"):format(tostring(key)), 2)
+		end
 	end,
 	__newindex = function(_tb, key, _value)
 		error(("Attempt to set Signal::%s (not a valid member)"):format(tostring(key)), 2)


### PR DESCRIPTION
I'll be making some major and minor optimizations to the whole library where necessary. These would include optimizations to collision detection, updating and rendering points and constraints, querying of rigid bodies during collision detection, collision related events of the Engine and RigidBodies, object creation and more.

The reason these optimizations are necessary is because of how the collisions between rigid bodies are not "rigid" enough, or in simple words - the rigid bodies are not really "rigid". They act more like soft bodies. And, the cause of this is because of the extremely low amount of iterations performed each for calculating and rendering physics. You may notice, rigid bodies start clipping into each other when their numbers are increased, since there is an exponential spike in the calculations that take place causing frame drops.

**Why do more iterations matter?** Currently, physics calculations and updates to physics objects are performed just once every RenderStepped. During low frame rates or even high frame rates, collisions tend to happen in between 2 rendered frames, commonly at low frame rates since the delta time is higher. This means, less collision checks and responses are performed and the physics objects are updated and rendered at low frequency causing them to clip into each other. Doing the same task multiple times helps in this case. For example, performing the physics calculations and updating the physics objects 6 times each frame means that there are 6 iterations being made. This maintains the "rigidness" of these physics objects and keeps them stable even at low frame rates.

A comparison between just 1 iteration and multiple iterations of physics calculations. From a [matter.js demo](https://brm.io/matter-js/demo/#stack).

| 1 Iteration | Multiple Iterations |
| - | - |
| Rigid bodies clip into each other very often. |  The rigid bodies don't clip into each other very often. |
| <img src="https://user-images.githubusercontent.com/74130881/148082997-43b586a4-90fe-4f8f-ac99-78b481495ed9.gif"> |  <img src="https://user-images.githubusercontent.com/74130881/148083072-5d207fad-b1a9-4e10-b76d-ca0d00d4e9cc.gif"> |

Hopefully these optimizations will help me add more iterations to the physics calculations to make the rigid bodies actually rigid. At present, this is not possible. More iterations equals more lag. 

This pull request will remain a draft until all changes have been made and revised. I look forward for reviews, feedback and suggestions if any.

Progress:
* Optimizations to how Rigid bodies are updated. There was a flaw earlier, I was using 2 for loops for the same task but in different locations. This has been cut down to just 1 loop. Commits related to this change:
    * 10c505ff8292d498b8951f24425f77d09ac373a6
    * e81e2ae30e04dfd909fd6efb398050de75081720
* Extra work for non-collidable rigid bodies is not longer performed.  PR related to this change:
    * #23 
* Events like .Touched and .TouchEnded are fired only if the events are connected using :Connect() somewhere. Commits related to this change:
    * 51010700ad179e8a321f028aa0061e439278a7c5
* Disconnect all Engine events when Engine:Stop() is called. 
* Warn and return from Engine:Start() if its already running.
* Disconnect and destroy RigidBody.TouchEnded event when RigidBody:Destoy() is called.