### PR TITLE
Improve Garbage Collection using Janitor

### DIFF
--- a/src/Physics/Constraint.lua
+++ b/src/Physics/Constraint.lua
@@ -1,6 +1,6 @@
 -- Constraints keep two points together in place and maintain uniform distance between the two.
--- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library. 
--- Custom constraints such as Ropes, Rods, Bridges and chains can also be made. 
+-- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library.
+-- Custom constraints such as Ropes, Rods, Bridges and chains can also be made.
 -- Points of two rigid bodies can be connected with constraints, two individual points can also be connected with constraints to form Ropes etc.
 
 -- Services and utilities
@@ -34,21 +34,21 @@ function Constraint.new(p1: Types.Point, p2: Types.Point, canvas: Types.Canvas, 
 		k = 0.1,
 		color = nil,
 	}, Constraint)
-	
+
 	local janitor = Janitor.new()
 	janitor:Add(self, "Destroy")
 	janitor:Add(self.point1, "Destroy")
 	janitor:Add(self.point2, "Destroy")
-	if self.Parent then 
+	if self.Parent then
 		janitor:Add(self.Parent, "Destroy")
 	end
 	self._janitor = janitor
-	
+
 	self.point1.Parent = self
 	self.point2.Parent = self
 	self.point1._janitor:Add(self.point1.Parent, "Destroy")
 	self.point2._janitor:Add(self.point2.Parent, "Destroy")
-	
+
 	return self
 end
 
@@ -56,21 +56,21 @@ end
 function Constraint:Constrain()
 	local cur = (self.point2.pos - self.point1.pos).Magnitude
 	local force
-	
+
 	-- Validate constraint types
-	if self._TYPE == "ROPE" then 
+	if self._TYPE == "ROPE" then
 		local restLength = self.restLength
-		if cur < self.thickness then 
+		if cur < self.thickness then
 			restLength = self.thickness
 		end
-		
-		if cur > self.restLength or self.restLength < self.thickness then 
+
+		if cur > self.restLength or self.restLength < self.thickness then
 			-- Solve rope constraint force
 			local offset = ((restLength - cur)/restLength)/2
-			force = self.point2.pos - self.point1.pos 
+			force = self.point2.pos - self.point1.pos
 			force *= offset
 		end
-	elseif self._TYPE == "ROD" then 
+	elseif self._TYPE == "ROD" then
 		-- Solve rod constraint force
 		local offset = self.restLength - cur
 		local dif = self.point2.pos - self.point1.pos
@@ -78,52 +78,50 @@ function Constraint:Constrain()
 		force = (dif * offset)/2
 	elseif self._TYPE == "SPRING" then
 		-- Solve spring constraint force
-		force = self.point2.pos - self.point1.pos 
+		force = self.point2.pos - self.point1.pos
 		local mag = force.Magnitude - self.restLength
 		force = force.Unit
 		force *= -1 * self.k * mag
 	else
 		return
 	end
-	
+
 	-- Apply forces to constraint's points
-	if force then 
+	if force then
 		if not self.point1.snap then self.point1.pos -= force end
-		if not self.point2.snap then self.point2.pos += force end		
+		if not self.point2.snap then self.point2.pos += force end
 	end
 end
 
 -- This method is used to update the position and appearance of the constraint on screen.
 function Constraint:Render()
 	if self.render and not self.support then
-		if not self.canvas.frame then 
+		if not self.canvas.frame then
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-		
+
 		local thickness = self.thickness or Globals.constraint.thickness
 		local color = self.color or Globals.constraint.color
 		local image = self._TYPE == "SPRING" and "rbxassetid://8404350124" or nil
-		
-		if not self.frame then 
+
+		if not self.frame then
 			self.frame = line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, nil, image)
-			
-			self._janitor:LinkToInstance(self.frame)
 			self._janitor:Add(self.frame, "Destroy")
 		end
-		
+
 		-- Draw constraint on screen
 		line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, self.frame, image)
 	end
 end
 
--- Used to set the minimum constrained distance between two points. 
+-- Used to set the minimum constrained distance between two points.
 -- By default, the initial distance between the two points.
 function Constraint:SetLength(newLength: number)
 	throwTypeError("length", newLength, 1, "number")
-	if newLength <= 0 then 
+	if newLength <= 0 then
 		throwException("error", "INVALID_CONSTRAINT_LENGTH")
 	end
-	
+
 	self.restLength = newLength
 end
 
@@ -132,25 +130,31 @@ function Constraint:GetLength() : number
 	return (self.point2.pos - self.point1.pos).Magnitude
 end
 
--- This method is used to change the color of a constraint. 
+-- This method is used to change the color of a constraint.
 -- By default a constraint's color is set to the default value of (WHITE) Color3.new(1, 1, 1).
 function Constraint:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method destroys the constraint. 
--- Its UI element is no longer rendered on screen and the constraint is removed from the engine. 
--- This is irreversible.	
+-- This method destroys the constraint.
+-- Its UI element is no longer rendered on screen and the constraint is removed from the engine.
+-- This is irreversible.
 function Constraint:Destroy()
 	self._janitor:Cleanup()
-	self.engine.ObjectRemoved:Fire(self)
-	
-	for i, c in ipairs(self.engine.constraints) do 
-		if c.id == self.id then 
-			table.remove(self.engine.constraints, i)
+
+	if not self.Parent then
+		for i, c in ipairs(self.engine.constraints) do
+			if c.id == self.id then
+				table.remove(self.engine.constraints, i)
+				self.engine.ObjectRemoved:Fire(self)
+				break
+			end
 		end
 	end
+
+	self.point1 = nil
+	self.point2 = nil
 end
 
 -- Returns the constraints points.

--- a/src/Physics/Constraint.lua
+++ b/src/Physics/Constraint.lua
@@ -1,6 +1,6 @@
 -- Constraints keep two points together in place and maintain uniform distance between the two.
--- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library.
--- Custom constraints such as Ropes, Rods, Bridges and chains can also be made.
+-- Constraints and Points together join to keep a RigidBody in place hence making both Points and Constraints a vital part of the library. 
+-- Custom constraints such as Ropes, Rods, Bridges and chains can also be made. 
 -- Points of two rigid bodies can be connected with constraints, two individual points can also be connected with constraints to form Ropes etc.
 
 -- Services and utilities
@@ -8,6 +8,7 @@ local line = require(script.Parent.Parent.Utilities.Line)
 local Globals = require(script.Parent.Parent.Constants.Globals)
 local throwTypeError = require(script.Parent.Parent.Debugging.TypeErrors)
 local throwException = require(script.Parent.Parent.Debugging.Exceptions)
+local Janitor = require(script.Parent.Parent.Utilities.Janitor)
 local Types = require(script.Parent.Parent.Types)
 local https = game:GetService("HttpService")
 
@@ -15,11 +16,12 @@ local Constraint = {}
 Constraint.__index = Constraint
 
 -- This method is used to initialize a constraint.
-function Constraint.new(p1: Types.Point, p2: Types.Point, canvas: Types.Canvas, config: Types.SegmentConfig, engine)
-	return setmetatable({
+function Constraint.new(p1: Types.Point, p2: Types.Point, canvas: Types.Canvas, config: Types.SegmentConfig, engine, parent)
+	local self = setmetatable({
 		id = https:GenerateGUID(false),
+		_janitor = nil,
 		engine = engine,
-		Parent = nil,
+		Parent = parent,
 		frame = nil,
 		canvas = canvas,
 		point1 = p1,
@@ -32,27 +34,43 @@ function Constraint.new(p1: Types.Point, p2: Types.Point, canvas: Types.Canvas, 
 		k = 0.1,
 		color = nil,
 	}, Constraint)
+	
+	local janitor = Janitor.new()
+	janitor:Add(self, "Destroy")
+	janitor:Add(self.point1, "Destroy")
+	janitor:Add(self.point2, "Destroy")
+	if self.Parent then 
+		janitor:Add(self.Parent, "Destroy")
+	end
+	self._janitor = janitor
+	
+	self.point1.Parent = self
+	self.point2.Parent = self
+	self.point1._janitor:Add(self.point1.Parent, "Destroy")
+	self.point2._janitor:Add(self.point2.Parent, "Destroy")
+	
+	return self
 end
 
 -- This method is used to keep uniform distance between the constraint's points, i.e. constrain.
 function Constraint:Constrain()
 	local cur = (self.point2.pos - self.point1.pos).Magnitude
 	local force
-
+	
 	-- Validate constraint types
-	if self._TYPE == "ROPE" then
+	if self._TYPE == "ROPE" then 
 		local restLength = self.restLength
-		if cur < self.thickness then
+		if cur < self.thickness then 
 			restLength = self.thickness
 		end
-
-		if cur > self.restLength or self.restLength < self.thickness then
+		
+		if cur > self.restLength or self.restLength < self.thickness then 
 			-- Solve rope constraint force
 			local offset = ((restLength - cur)/restLength)/2
-			force = self.point2.pos - self.point1.pos
+			force = self.point2.pos - self.point1.pos 
 			force *= offset
 		end
-	elseif self._TYPE == "ROD" then
+	elseif self._TYPE == "ROD" then 
 		-- Solve rod constraint force
 		local offset = self.restLength - cur
 		local dif = self.point2.pos - self.point1.pos
@@ -60,49 +78,52 @@ function Constraint:Constrain()
 		force = (dif * offset)/2
 	elseif self._TYPE == "SPRING" then
 		-- Solve spring constraint force
-		force = self.point2.pos - self.point1.pos
+		force = self.point2.pos - self.point1.pos 
 		local mag = force.Magnitude - self.restLength
 		force = force.Unit
 		force *= -1 * self.k * mag
 	else
 		return
 	end
-
+	
 	-- Apply forces to constraint's points
-	if force then
+	if force then 
 		if not self.point1.snap then self.point1.pos -= force end
-		if not self.point2.snap then self.point2.pos += force end
+		if not self.point2.snap then self.point2.pos += force end		
 	end
 end
 
 -- This method is used to update the position and appearance of the constraint on screen.
 function Constraint:Render()
 	if self.render and not self.support then
-		if not self.canvas.frame then
+		if not self.canvas.frame then 
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-
+		
 		local thickness = self.thickness or Globals.constraint.thickness
 		local color = self.color or Globals.constraint.color
 		local image = self._TYPE == "SPRING" and "rbxassetid://8404350124" or nil
-
-		if not self.frame then
+		
+		if not self.frame then 
 			self.frame = line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, nil, image)
+			
+			self._janitor:LinkToInstance(self.frame)
+			self._janitor:Add(self.frame, "Destroy")
 		end
-
+		
 		-- Draw constraint on screen
 		line(self.point1.pos, self.point2.pos, self.canvas.frame, thickness, color, self.frame, image)
 	end
 end
 
--- Used to set the minimum constrained distance between two points.
+-- Used to set the minimum constrained distance between two points. 
 -- By default, the initial distance between the two points.
 function Constraint:SetLength(newLength: number)
 	throwTypeError("length", newLength, 1, "number")
-	if newLength <= 0 then
+	if newLength <= 0 then 
 		throwException("error", "INVALID_CONSTRAINT_LENGTH")
 	end
-
+	
 	self.restLength = newLength
 end
 
@@ -111,29 +132,24 @@ function Constraint:GetLength() : number
 	return (self.point2.pos - self.point1.pos).Magnitude
 end
 
--- This method is used to change the color of a constraint.
+-- This method is used to change the color of a constraint. 
 -- By default a constraint's color is set to the default value of (WHITE) Color3.new(1, 1, 1).
 function Constraint:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method destroys the constraint.
--- Its UI element is no longer rendered on screen and the constraint is removed from the engine.
--- This is irreversible.
+-- This method destroys the constraint. 
+-- Its UI element is no longer rendered on screen and the constraint is removed from the engine. 
+-- This is irreversible.	
 function Constraint:Destroy()
-	if self.engine then
-		if self.frame then
-			self.frame:Destroy()
+	self._janitor:Cleanup()
+	self.engine.ObjectRemoved:Fire(self)
+	
+	for i, c in ipairs(self.engine.constraints) do 
+		if c.id == self.id then 
+			table.remove(self.engine.constraints, i)
 		end
-
-		for i, c in ipairs(self.engine.constraints) do
-			if c.id == self.id then
-				table.remove(self.engine.constraints, i)
-			end
-		end
-
-		self.engine.ObjectRemoved:Fire(self)
 	end
 end
 

--- a/src/Physics/Point.lua
+++ b/src/Physics/Point.lua
@@ -1,4 +1,4 @@
--- Points are what make the rigid bodies behave like real world entities.
+-- Points are what make the rigid bodies behave like real world entities. 
 -- Points are responsible for the movement of the RigidBodies and Constraints.
 
 -- Services and utilities
@@ -6,15 +6,19 @@ local Globals = require(script.Parent.Parent.Constants.Globals)
 local Types = require(script.Parent.Parent.Types)
 local throwTypeError = require(script.Parent.Parent.Debugging.TypeErrors)
 local throwException = require(script.Parent.Parent.Debugging.Exceptions)
+local Janitor = require(script.Parent.Parent.Utilities.Janitor)
+local HttpService = game:GetService("HttpService")
 
 local Point = {}
 Point.__index = Point
 
 -- This method is used to initialize a new Point.
-function Point.new(pos: Vector2, canvas: Types.Canvas, engine: Types.EngineConfig, config: Types.PointConfig)
+function Point.new(pos: Vector2, canvas: Types.Canvas, engine: Types.EngineConfig, config: Types.PointConfig, parent)
 	local self = setmetatable({
-		Parent = nil,
+		id = HttpService:GenerateGUID(false),
+		Parent = parent,
 		frame = nil,
+		_janitor = nil,
 		engine = engine,
 		canvas = canvas,
 		oldPos = pos,
@@ -37,24 +41,31 @@ function Point.new(pos: Vector2, canvas: Types.Canvas, engine: Types.EngineConfi
 			force = Vector2.new()
 		}
 	}, Point)
-
+	
+	local janitor = Janitor.new()
+	janitor:Add(self, "Destroy")
+	if self.Parent then 
+		janitor:Add(self.Parent, "Destroy")
+	end
+	self._janitor = janitor
+	
 	return self
 end
 
--- This method is used to apply a force to the Point.
+-- This method is used to apply a force to the Point. 
 function Point:ApplyForce(force: Vector2, t: number)
 	throwTypeError("force", force, 1, "Vector2")
 	self.forces += force
-
-	if t then
+		
+	if t then 
 		throwTypeError("time", t, 2, "number")
 		if t <= 0 then
 			throwException("error", "INVALID_TIME")
 		end
-
+		
 		self.timed.start = os.clock()
 		self.timed.t = t
-		self.timed.force = force
+		self.timed.force = force 
 	end
 end
 
@@ -62,9 +73,9 @@ end
 function Point:Update(dt: number)
 	if not self.snap then
 		self:ApplyForce(self.gravity)
-
-		if self.timed.start then
-			if os.clock() - self.timed.start < self.timed.t then
+		
+		if self.timed.start then 
+			if os.clock() - self.timed.start < self.timed.t then 
 				self:ApplyForce(self.timed.force)
 			else
 				self.timed.start = nil
@@ -72,42 +83,42 @@ function Point:Update(dt: number)
 				self.timed.force = Vector2.new()
 			end
 		end
-
+		
 		-- Calculate velocity
-		local velocity = self.pos
+		local velocity = self.pos 
 		velocity -= self.oldPos
-		if self.engine.independent then
+		if self.engine.independent then 
 			self.forces *= dt * self.engine.speed
 		end
-		velocity += self.forces
-
+		velocity += self.forces 
+		
 		local body = self.Parent
-
+		
 		-- Apply friction
-		if body and body.Parent then
+		if body and body.Parent then 
 			local mass = body.Parent.mass
-
-			if mass then
+			
+			if mass then 
 				self.forces /= mass
 			end
-
-			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then
-				velocity *= self.friction
-			else
+			
+			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then 
+				velocity *= self.friction 
+			else 
 				velocity *= self.airfriction
-			end
-		else
+			end			
+		else 
 			velocity *= self.friction
 		end
-
+		
 		-- clamp velocity
-		if self.maxForce then
+		if self.maxForce then 
 			velocity = Vector2.new(
 				math.clamp(velocity.X, -self.maxForce, self.maxForce),
 				math.clamp(velocity.Y, -self.maxForce, self.maxForce)
 			)
 		end
-
+		
 		-- Update point positions
 		self.oldPos = self.pos
 		self.pos += velocity
@@ -115,8 +126,8 @@ function Point:Update(dt: number)
 	end
 end
 
--- This method is used to keep the point in the engine's canvas.
--- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly.
+-- This method is used to keep the point in the engine's canvas. 
+-- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly. 
 function Point:KeepInCanvas()
 	-- vx = velocity.X
 	-- vy = velocity.Y
@@ -128,39 +139,39 @@ function Point:KeepInCanvas()
 
 	local collision = false
 	local edge
-
+	
 	if self.pos.Y > boundY then
-		self.pos = Vector2.new(self.pos.X, boundY)
+		self.pos = Vector2.new(self.pos.X, boundY) 
 		self.oldPos = Vector2.new(self.oldPos.X, self.pos.Y + vy * self.bounce)
 		collision = true
 		edge = "Bottom"
 	elseif self.pos.Y < self.canvas.topLeft.Y then
-		self.pos = Vector2.new(self.pos.X, self.canvas.topLeft.Y)
+		self.pos = Vector2.new(self.pos.X, self.canvas.topLeft.Y) 
 		self.oldPos = Vector2.new(self.oldPos.X, self.pos.Y - vy * self.bounce)
 		collision = true
 		edge = "Top"
 	end
 
 	if self.pos.X < self.canvas.topLeft.X then
-		self.pos = Vector2.new(self.canvas.topLeft.X, self.pos.Y)
+		self.pos = Vector2.new(self.canvas.topLeft.X, self.pos.Y) 
 		self.oldPos = Vector2.new(self.pos.X + vx * self.bounce, self.oldPos.Y)
 		collision = true
 		edge = "Left"
 	elseif self.pos.X > boundX then
-		self.pos = Vector2.new(boundX, self.pos.Y)
+		self.pos = Vector2.new(boundX, self.pos.Y) 
 		self.oldPos = Vector2.new(self.pos.X - vx * self.bounce, self.oldPos.Y)
 		collision = true
 		edge = "Right"
 	end
-
+	
 	local body = self.Parent
-
+	
 	-- Fire CanvasEdgeTouched event
-	if body and body.Parent then
-		if collision then
+	if body and body.Parent then 
+		if collision then 
 			local prev = body.Parent.Collisions.CanvasEdge
 			body.Parent.Collisions.CanvasEdge = true
-			if prev == false then
+			if prev == false then 
 				body.Parent.CanvasEdgeTouched:Fire(edge)
 			end
 		else
@@ -171,17 +182,17 @@ end
 
 -- This method is used to update the position and appearance of the Point on screen.
 function Point:Render()
-	if self.render then
-		if not self.canvas.frame then
+	if self.render then 
+		if not self.canvas.frame then 
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-
-		if not self.frame then
+				
+		if not self.frame then 
 			-- Create new instance for the point
 			local p = Instance.new("Frame")
 			local border = Instance.new("UICorner")
 			local r = self.radius or Globals.point.radius
-
+			
 			p.AnchorPoint = Vector2.new(.5, .5)
 			p.BackgroundColor3 = self.color or Globals.point.color
 			p.Size = UDim2.new(0, r * 2, 0, r * 2)
@@ -191,14 +202,28 @@ function Point:Render()
 			border.Parent = p
 
 			self.frame = p
+						
+			self._janitor:LinkToInstance(self.frame)
+			self._janitor:Add(self.frame, "Destroy")
 		end
-
+		
 		-- Update the point's instance
 		self.frame.Position = UDim2.new(0, self.pos.x, 0, self.pos.y)
 	end
-
-	if self.keepInCanvas then
+	
+	if self.keepInCanvas then 
 		self:KeepInCanvas()
+	end
+end
+
+function Point:Destroy()
+	self._janitor:Cleanup()	
+	self.engine.ObjectRemoved:Fire(self)
+	
+	for i, c in ipairs(self.engine.points) do 
+		if c.id == self.id then 
+			table.remove(self.engine.points, i)
+		end
 	end
 end
 
@@ -208,14 +233,14 @@ function Point:SetRadius(radius: number)
 	self.radius = radius
 end
 
--- his method is used to determine the color of the point on screen.
+-- his method is used to determine the color of the point on screen. 
 -- By default this is set to (RED) Color3.new(1, 0, 0).
 function Point:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method determines if the point remains anchored.
+-- This method determines if the point remains anchored. 
 -- If set to false, the point is unanchored.
 function Point:Snap(snap: boolean)
 	throwTypeError("snap", snap, 1, "boolean")

--- a/src/Physics/Point.lua
+++ b/src/Physics/Point.lua
@@ -1,4 +1,4 @@
--- Points are what make the rigid bodies behave like real world entities. 
+-- Points are what make the rigid bodies behave like real world entities.
 -- Points are responsible for the movement of the RigidBodies and Constraints.
 
 -- Services and utilities
@@ -41,31 +41,31 @@ function Point.new(pos: Vector2, canvas: Types.Canvas, engine: Types.EngineConfi
 			force = Vector2.new()
 		}
 	}, Point)
-	
+
 	local janitor = Janitor.new()
 	janitor:Add(self, "Destroy")
-	if self.Parent then 
+	if self.Parent then
 		janitor:Add(self.Parent, "Destroy")
 	end
 	self._janitor = janitor
-	
+
 	return self
 end
 
--- This method is used to apply a force to the Point. 
+-- This method is used to apply a force to the Point.
 function Point:ApplyForce(force: Vector2, t: number)
 	throwTypeError("force", force, 1, "Vector2")
 	self.forces += force
-		
-	if t then 
+
+	if t then
 		throwTypeError("time", t, 2, "number")
 		if t <= 0 then
 			throwException("error", "INVALID_TIME")
 		end
-		
+
 		self.timed.start = os.clock()
 		self.timed.t = t
-		self.timed.force = force 
+		self.timed.force = force
 	end
 end
 
@@ -73,9 +73,9 @@ end
 function Point:Update(dt: number)
 	if not self.snap then
 		self:ApplyForce(self.gravity)
-		
-		if self.timed.start then 
-			if os.clock() - self.timed.start < self.timed.t then 
+
+		if self.timed.start then
+			if os.clock() - self.timed.start < self.timed.t then
 				self:ApplyForce(self.timed.force)
 			else
 				self.timed.start = nil
@@ -83,42 +83,42 @@ function Point:Update(dt: number)
 				self.timed.force = Vector2.new()
 			end
 		end
-		
+
 		-- Calculate velocity
-		local velocity = self.pos 
+		local velocity = self.pos
 		velocity -= self.oldPos
-		if self.engine.independent then 
+		if self.engine.independent then
 			self.forces *= dt * self.engine.speed
 		end
-		velocity += self.forces 
-		
+		velocity += self.forces
+
 		local body = self.Parent
-		
+
 		-- Apply friction
-		if body and body.Parent then 
+		if body and body.Parent then
 			local mass = body.Parent.mass
-			
-			if mass then 
+
+			if mass then
 				self.forces /= mass
 			end
-			
-			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then 
-				velocity *= self.friction 
-			else 
+
+			if body.Parent.Collisions.CanvasEdge or body.Parent.Collisions.Body then
+				velocity *= self.friction
+			else
 				velocity *= self.airfriction
-			end			
-		else 
+			end
+		else
 			velocity *= self.friction
 		end
-		
+
 		-- clamp velocity
-		if self.maxForce then 
+		if self.maxForce then
 			velocity = Vector2.new(
 				math.clamp(velocity.X, -self.maxForce, self.maxForce),
 				math.clamp(velocity.Y, -self.maxForce, self.maxForce)
 			)
 		end
-		
+
 		-- Update point positions
 		self.oldPos = self.pos
 		self.pos += velocity
@@ -126,8 +126,8 @@ function Point:Update(dt: number)
 	end
 end
 
--- This method is used to keep the point in the engine's canvas. 
--- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly. 
+-- This method is used to keep the point in the engine's canvas.
+-- Any point that goes past the canvas, is positioned correctly and the direction of its flipped is reversed accordingly.
 function Point:KeepInCanvas()
 	-- vx = velocity.X
 	-- vy = velocity.Y
@@ -139,39 +139,39 @@ function Point:KeepInCanvas()
 
 	local collision = false
 	local edge
-	
+
 	if self.pos.Y > boundY then
-		self.pos = Vector2.new(self.pos.X, boundY) 
+		self.pos = Vector2.new(self.pos.X, boundY)
 		self.oldPos = Vector2.new(self.oldPos.X, self.pos.Y + vy * self.bounce)
 		collision = true
 		edge = "Bottom"
 	elseif self.pos.Y < self.canvas.topLeft.Y then
-		self.pos = Vector2.new(self.pos.X, self.canvas.topLeft.Y) 
+		self.pos = Vector2.new(self.pos.X, self.canvas.topLeft.Y)
 		self.oldPos = Vector2.new(self.oldPos.X, self.pos.Y - vy * self.bounce)
 		collision = true
 		edge = "Top"
 	end
 
 	if self.pos.X < self.canvas.topLeft.X then
-		self.pos = Vector2.new(self.canvas.topLeft.X, self.pos.Y) 
+		self.pos = Vector2.new(self.canvas.topLeft.X, self.pos.Y)
 		self.oldPos = Vector2.new(self.pos.X + vx * self.bounce, self.oldPos.Y)
 		collision = true
 		edge = "Left"
 	elseif self.pos.X > boundX then
-		self.pos = Vector2.new(boundX, self.pos.Y) 
+		self.pos = Vector2.new(boundX, self.pos.Y)
 		self.oldPos = Vector2.new(self.pos.X - vx * self.bounce, self.oldPos.Y)
 		collision = true
 		edge = "Right"
 	end
-	
+
 	local body = self.Parent
-	
+
 	-- Fire CanvasEdgeTouched event
-	if body and body.Parent then 
-		if collision then 
+	if body and body.Parent then
+		if collision then
 			local prev = body.Parent.Collisions.CanvasEdge
 			body.Parent.Collisions.CanvasEdge = true
-			if prev == false then 
+			if prev == false then
 				body.Parent.CanvasEdgeTouched:Fire(edge)
 			end
 		else
@@ -182,17 +182,17 @@ end
 
 -- This method is used to update the position and appearance of the Point on screen.
 function Point:Render()
-	if self.render then 
-		if not self.canvas.frame then 
+	if self.render then
+		if not self.canvas.frame then
 			throwException("error", "CANVAS_FRAME_NOT_FOUND")
 		end
-				
-		if not self.frame then 
+
+		if not self.frame then
 			-- Create new instance for the point
 			local p = Instance.new("Frame")
 			local border = Instance.new("UICorner")
 			local r = self.radius or Globals.point.radius
-			
+
 			p.AnchorPoint = Vector2.new(.5, .5)
 			p.BackgroundColor3 = self.color or Globals.point.color
 			p.Size = UDim2.new(0, r * 2, 0, r * 2)
@@ -202,27 +202,29 @@ function Point:Render()
 			border.Parent = p
 
 			self.frame = p
-						
-			self._janitor:LinkToInstance(self.frame)
+
 			self._janitor:Add(self.frame, "Destroy")
 		end
-		
+
 		-- Update the point's instance
 		self.frame.Position = UDim2.new(0, self.pos.x, 0, self.pos.y)
 	end
-	
-	if self.keepInCanvas then 
+
+	if self.keepInCanvas then
 		self:KeepInCanvas()
 	end
 end
 
 function Point:Destroy()
-	self._janitor:Cleanup()	
-	self.engine.ObjectRemoved:Fire(self)
-	
-	for i, c in ipairs(self.engine.points) do 
-		if c.id == self.id then 
-			table.remove(self.engine.points, i)
+	self._janitor:Cleanup()
+
+	if not self.Parent then
+		for i, c in ipairs(self.engine.points) do
+			if c.id == self.id then
+				table.remove(self.engine.points, i)
+				self.engine.ObjectRemoved:Fire(self)
+				break
+			end
 		end
 	end
 end
@@ -233,14 +235,14 @@ function Point:SetRadius(radius: number)
 	self.radius = radius
 end
 
--- his method is used to determine the color of the point on screen. 
+-- his method is used to determine the color of the point on screen.
 -- By default this is set to (RED) Color3.new(1, 0, 0).
 function Point:Stroke(color: Color3)
 	throwTypeError("color", color, 1, "Color3")
 	self.color = color
 end
 
--- This method determines if the point remains anchored. 
+-- This method determines if the point remains anchored.
 -- If set to false, the point is unanchored.
 function Point:Snap(snap: boolean)
 	throwTypeError("snap", snap, 1, "boolean")

--- a/src/Physics/RigidBody.lua
+++ b/src/Physics/RigidBody.lua
@@ -204,10 +204,8 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 	self.TouchEnded = Signal.new()
 	self.CanvasEdgeTouched = Signal.new()
 
-	-- Set parents of points and constraints
+	-- Set parents of constraints
 	for _, edge in ipairs(edges) do
-		edge.point1.Parent = edge
-		edge.point2.Parent = edge
 		edge.Parent = self
 	end
 

--- a/src/Physics/RigidBody.lua
+++ b/src/Physics/RigidBody.lua
@@ -6,6 +6,7 @@ local Constraint = require(script.Parent.Constraint)
 local Globals = require(script.Parent.Parent.Constants.Globals)
 local Signal = require(script.Parent.Parent.Utilities.Signal)
 local Types = require(script.Parent.Parent.Types)
+local Janitor = require(script.Parent.Parent.Utilities.Janitor)
 local throwTypeError = require(script.Parent.Parent.Debugging.TypeErrors)
 local throwException = require(script.Parent.Parent.Debugging.Exceptions)
 local restrict = require(script.Parent.Parent.Debugging.Restrict)
@@ -90,6 +91,16 @@ local function CalculateSize(vertices)
 	return Vector2.new(maxX - minX, maxY - minY)
 end
 
+local function CreateRotationCache(cache, center, vertices)
+	table.clear(cache)
+
+	for _, p in ipairs(vertices) do
+		local r = (p.pos - center).Magnitude
+		local theta = math.atan2(p.pos.Y - center.Y, p.pos.X - center.X)
+		table.insert(cache, { r, theta })
+	end
+end
+
 -- This method is used to update the positions of each point of a rigidbody to the corners of a UI element.
 local function UpdateVertices(frame: GuiObject, vertices, engine)
 	local corners = GetCorners(frame, engine)
@@ -164,7 +175,7 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 	local self = setmetatable({
 		id = HttpService:GenerateGUID(false),
 		custom = isCustom,
-		structure = structure,
+		_janitor = Janitor.new(),		structure = structure,
 		vertices = vertices,
 		edges = edges,
 		frame = isCustom and nil or frame,
@@ -196,7 +207,13 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 	-- Offset = Vector2.new(0, 36)
 	if engine.path and engine.path.IgnoreGuiInset then
 		self.anchorPos = self.anchorPos and self.anchorPos + Globals.offset or nil
-		self.center += Globals.offset
+		if not self.custom then
+			self.center += Globals.offset
+		end
+	end
+
+	if #self.rotationCache < 1 then
+		CreateRotationCache(self.rotationCache, self.center, self.vertices)
 	end
 
 	-- Create events
@@ -204,9 +221,20 @@ function RigidBody.new(frame: GuiObject?, m: number, collidable: boolean?, ancho
 	self.TouchEnded = Signal.new()
 	self.CanvasEdgeTouched = Signal.new()
 
-	-- Set parents of constraints
+	-- Set parents of points and constraints
 	for _, edge in ipairs(edges) do
 		edge.Parent = self
+		edge._janitor:Add(edge.Parent, "Destroy")
+		self._janitor:Add(edge, "Destroy")
+	end
+
+	self._janitor:Add(self.Touched, "Destroy")
+	self._janitor:Add(self.TouchEnded, "Destroy")
+	self._janitor:Add(self.CanvasEdgeTouched, "Destroy")
+
+	if not self.custom then
+		self._janitor:Add(self.frame, "Destroy")
+		self._janitor:LinkToInstance(self.frame)
 	end
 
 	return self
@@ -325,17 +353,15 @@ end
 function RigidBody:Update(dt: number)
 	self.center = CalculateCenter(self.vertices)
 
-	if not self.canRotate then
-		for i, info in ipairs(self.rotationCache) do
+	for i, vertex in ipairs(self.vertices) do
+		if not self.canRotate then
+			local info = self.rotationCache[i]
 			local r = info[1]
 			local t = info[2]
-			local v = self.vertices[i]
 
-			v:ApplyForce((self.center + Vector2.new(math.cos(t), math.sin(t)) * r) - v.pos)
+			vertex:ApplyForce((self.center + Vector2.new(math.cos(t), math.sin(t)) * r) - vertex.pos)
 		end
-	end
 
-	for _, vertex in ipairs(self.vertices) do
 		vertex:Update(dt)
 		vertex:Render()
 	end
@@ -415,38 +441,24 @@ end
 -- This method is used to destroy the RigidBody.
 -- The body's UI element is destroyed, its connections are disconnected and the body is removed from the engine.
 function RigidBody:Destroy(keepFrame: boolean)
+	self._janitor:Cleanup()
+
 	for i, body in ipairs(self.engine.bodies) do
 		if self.id == body.id then
-			-- Destroy events
-			-- Destroy the frame and remove the RigidBody from the Engine.
-			self.Touched:Destroy()
-			self.CanvasEdgeTouched:Destroy()
-			self.TouchEnded:Destroy()
-			self.Touched = nil
-			self.CanvasEdgeTouched = nil
-			self.TouchEnded = nil
-			if not self.custom and not keepFrame then
-				self.frame:Destroy()
-			end
-			if self.custom and not keepFrame then
-				for _, c in ipairs(self.edges) do
-					if c.frame then
-						c.frame:Destroy()
-					end
-				end
-			end
 			table.clear(self.Collisions.Other)
 			table.remove(self.engine.bodies, i)
 			self.engine.ObjectRemoved:Fire(self)
 			break
 		end
 	end
+
+	table.clear(self.vertices)
+	table.clear(self.edges)
 end
 
 -- This method is used to rotate the RigidBody's UI element.
 -- After rotation the positions of its points and constraints are automatically updated.
 function RigidBody:Rotate(newRotation: number)
-	restrict(self.custom)
 	throwTypeError("newRotation", newRotation, 1, "number")
 
 	-- Update anchorRotation if the body is anchored
@@ -456,19 +468,41 @@ function RigidBody:Rotate(newRotation: number)
 
 	-- Apply rotation and update positions
 	-- Update the RigidBody's points
-	local oldRotation = self.frame.Rotation
-	local offset = CalculateOffset(self.anchorPos, self.frame.AnchorPoint, self.frame.AbsoluteSize)
-	local position = self.anchorPos - offset
-	self.frame.Position = self.anchored and UDim2.fromOffset(position.X, position.Y)  or UDim2.fromOffset(self.center.x, self.center.y)
-	self.frame.Rotation = newRotation
-	UpdateVertices(self.frame, self.vertices, self.engine)
+	local oldRotation
+
+	if self.custom then
+		-- Will need to cache oldRotation somewhere.
+		-- This method will result in weird oldRotations for some custom rigid bodies.
+		local dif = self.vertices[2].pos - self.vertices[1].pos
+		oldRotation = math.deg(math.atan2(dif.Y, dif.X))
+
+		local tempRotationCache = {}
+		CreateRotationCache(tempRotationCache, self.center, self.vertices)
+
+		for i, info in ipairs(tempRotationCache) do
+			local r = info[1]
+			local t = info[2] + math.rad(newRotation)
+			local v = self.vertices[i]
+
+			v.pos = self.center + Vector2.new(math.cos(t), math.sin(t)) * r
+			v.oldPos = v.pos
+		end
+	else
+		oldRotation = self.frame.Rotation
+
+		local offset = CalculateOffset(self.anchorPos, self.frame.AnchorPoint, self.frame.AbsoluteSize)
+		local position = self.anchorPos - offset
+		self.frame.Position = self.anchored and UDim2.fromOffset(position.X, position.Y) or UDim2.fromOffset(self.center.x, self.center.y)
+		self.frame.Rotation = newRotation
+		UpdateVertices(self.frame, self.vertices, self.engine)
+	end
 
 	return oldRotation, newRotation
 end
 
 -- This method is used to set a new position of the RigidBody's UI element.
 function RigidBody:SetPosition(PositionX: number, PositionY: number)
-	restrict(self.custom)
+	--restrict(self.custom)
 	throwTypeError("PositionX", PositionX, 1, "number")
 	throwTypeError("PositionY", PositionY, 2, "number")
 
@@ -477,11 +511,30 @@ function RigidBody:SetPosition(PositionX: number, PositionY: number)
 		self.anchorPos = Vector2.new(PositionX, PositionY)
 	end
 
+	local oldPosition
+
 	-- Update position
 	-- Update the RigidBody's points
-	local oldPosition = self.frame.Position
-	self.frame.Position = UDim2.fromOffset(PositionX, PositionY)
-	UpdateVertices(self.frame, self.vertices, self.engine)
+	if self.custom then
+		oldPosition = UDim2.fromOffset(self.center.X, self.center.Y)
+		local tempRotationCache = {}
+		CreateRotationCache(tempRotationCache, self.center, self.vertices)
+
+		self.center = Vector2.new(PositionX, PositionY)
+
+		for i, info in ipairs(tempRotationCache) do
+			local r = info[1]
+			local t = info[2]
+			local v = self.vertices[i]
+
+			v.pos = self.center + Vector2.new(math.cos(t), math.sin(t)) * r
+			v.oldPos = v.pos
+		end
+	else
+		oldPosition = self.frame.Position
+		self.frame.Position = UDim2.fromOffset(PositionX, PositionY)
+		UpdateVertices(self.frame, self.vertices, self.engine)
+	end
 
 	return oldPosition, UDim2.fromOffset(PositionX, PositionY)
 end
@@ -498,7 +551,30 @@ function RigidBody:SetSize(SizeX: number, SizeY: number)
 	self.frame.Size = UDim2.fromOffset(SizeX, SizeY)
 	UpdateVertices(self.frame, self.vertices, self.engine)
 
+	for _, edge in ipairs(self.edges) do
+		edge.restLength = (edge.point2.pos - edge.point1.pos).Magnitude
+	end
+
 	return oldSize, UDim2.fromOffset(SizeX, SizeY)
+end
+
+function RigidBody:SetScale(scale: number)
+	if not self.custom then return end
+	throwTypeError("scale", scale, 1, "number")
+	scale = math.max(0.00001, scale)
+
+	for i, info in ipairs(self.rotationCache) do
+		local r = info[1] * scale
+		local t = info[2]
+		local v = self.vertices[i]
+
+		v.pos = self.center + Vector2.new(math.cos(t), math.sin(t)) * r
+		v.oldPos = v.pos
+	end
+
+	for _, edge in ipairs(self.edges) do
+		edge.restLength = (edge.point2.pos - edge.point1.pos).Magnitude
+	end
 end
 
 -- This method is used to anchor the RigidBody.
@@ -535,13 +611,7 @@ function RigidBody:CanRotate(canRotate: boolean)
 	throwTypeError("canRotate", canRotate, 1, "boolean")
 	self.canRotate = canRotate
 
-	if not self.canRotate then
-		for _, p in ipairs(self.vertices) do
-			local r = (p.pos - self.center).Magnitude
-			local theta = math.atan2(p.pos.Y - self.center.Y, p.pos.X - self.center.X)
-			table.insert(self.rotationCache, { r, theta })
-		end
-	end
+	CreateRotationCache(self.rotationCache, self.center, self.vertices)
 end
 
 -- The RigidBody's UI Element can be fetched using this method.

--- a/src/Utilities/Janitor/GetPromiseLibrary.lua
+++ b/src/Utilities/Janitor/GetPromiseLibrary.lua
@@ -1,0 +1,47 @@
+-- TODO: When Promise is on Wally, remove this in favor of just `script.Parent.Parent:FindFirstChild("Promise")`.
+local ReplicatedFirst = game:GetService("ReplicatedFirst")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
+local ServerStorage = game:GetService("ServerStorage")
+
+local LOCATIONS_TO_SEARCH = {script.Parent.Parent, ReplicatedFirst, ReplicatedStorage, ServerScriptService, ServerStorage}
+
+local function FindFirstDescendantWithNameAndClassName(Parent: Instance, Name: string, ClassName: string)
+	for _, Descendant in ipairs(Parent:GetDescendants()) do
+		if Descendant:IsA(ClassName) and Descendant.Name == Name then
+			return Descendant
+		end
+	end
+
+	return nil
+end
+
+local function GetPromiseLibrary()
+	-- I'm not too keen on how this is done.
+	-- It's better than the multiple if statements (probably).
+	local Plugin = script:FindFirstAncestorOfClass("Plugin")
+	if Plugin then
+		local Promise = FindFirstDescendantWithNameAndClassName(Plugin, "Promise", "ModuleScript")
+		if Promise then
+			return true, require(Promise)
+		else
+			return false
+		end
+	end
+
+	local Promise
+	for _, Location in ipairs(LOCATIONS_TO_SEARCH) do
+		Promise = FindFirstDescendantWithNameAndClassName(Location, "Promise", "ModuleScript")
+		if Promise then
+			break
+		end
+	end
+
+	if Promise then
+		return true, require(Promise)
+	else
+		return false
+	end
+end
+
+return GetPromiseLibrary

--- a/src/Utilities/Janitor/Symbol.lua
+++ b/src/Utilities/Janitor/Symbol.lua
@@ -1,0 +1,12 @@
+-- This only exists because the LSP warns Key `__tostring` not found in type `table?`.
+local function Symbol(Name: string)
+	local self = newproxy(true)
+	local Metatable = getmetatable(self)
+	function Metatable.__tostring()
+		return Name
+	end
+
+	return self
+end
+
+return Symbol

--- a/src/Utilities/Janitor/init.lua
+++ b/src/Utilities/Janitor/init.lua
@@ -1,0 +1,467 @@
+-- Janitor
+-- Original by Validark
+-- Modifications by pobammer
+-- roblox-ts support by OverHash and Validark
+-- LinkToInstance fixed by Elttob.
+-- Cleanup edge cases fixed by codesenseAye.
+
+local GetPromiseLibrary = require(script.GetPromiseLibrary)
+local Symbol = require(script.Symbol)
+local FoundPromiseLibrary, Promise = GetPromiseLibrary()
+
+local IndicesReference = Symbol("IndicesReference")
+local LinkToInstanceIndex = Symbol("LinkToInstanceIndex")
+
+local METHOD_NOT_FOUND_ERROR = "Object %s doesn't have method %s, are you sure you want to add it? Traceback: %s"
+local NOT_A_PROMISE = "Invalid argument #1 to 'Janitor:AddPromise' (Promise expected, got %s (%s))"
+
+--[=[
+	Janitor is a light-weight, flexible object for cleaning up connections, instances, or anything. This implementation covers all use cases,
+	as it doesn't force you to rely on naive typechecking to guess how an instance should be cleaned up.
+	Instead, the developer may specify any behavior for any object.
+
+	@class Janitor
+]=]
+local Janitor = {}
+Janitor.ClassName = "Janitor"
+Janitor.CurrentlyCleaning = true
+Janitor[IndicesReference] = nil
+Janitor.__index = Janitor
+
+local TypeDefaults = {
+	["function"] = true;
+	RBXScriptConnection = "Disconnect";
+}
+
+--[=[
+	Determines if the passed object is a Janitor. This checks the metatable directly.
+
+	@param Object any -- The object you are checking.
+	@return boolean -- `true` if `Object` is a Janitor.
+]=]
+function Janitor.Is(Object: any): boolean
+	return type(Object) == "table" and getmetatable(Object) == Janitor
+end
+
+type StringOrTrue = string | boolean
+
+--[=[
+	Adds an `Object` to Janitor for later cleanup, where `MethodName` is the key of the method within `Object` which should be called at cleanup time.
+	If the `MethodName` is `true` the `Object` itself will be called instead. If passed an index it will occupy a namespace which can be `Remove()`d or overwritten.
+	Returns the `Object`.
+
+	:::info
+	Objects not given an explicit `MethodName` will be passed into the `typeof` function for a very naive typecheck.
+	RBXConnections will be assigned to "Disconnect", functions will be assigned to `true`, and everything else will default to "Destroy".
+	Not recommended, but hey, you do you.
+	:::
+
+	```lua
+	local Workspace = game:GetService("Workspace")
+	local TweenService = game:GetService("TweenService")
+
+	local Obliterator = Janitor.new()
+	local Part = Workspace.Part
+
+	-- Queue the Part to be Destroyed at Cleanup time
+	Obliterator:Add(Part, "Destroy")
+
+	-- Queue function to be called with `true` MethodName
+	Obliterator:Add(print, true)
+
+	-- This implementation allows you to specify behavior for any object
+	Obliterator:Add(TweenService:Create(Part, TweenInfo.new(1), {Size = Vector3.new(1, 1, 1)}), "Cancel")
+
+	-- By passing an Index, the Object will occupy a namespace
+	-- If "CurrentTween" already exists, it will call :Remove("CurrentTween") before writing
+	Obliterator:Add(TweenService:Create(Part, TweenInfo.new(1), {Size = Vector3.new(1, 1, 1)}), "Destroy", "CurrentTween")
+	```
+
+	```ts
+	import { Workspace, TweenService } from "@rbxts/services";
+	import { Janitor } from "@rbxts/janitor";
+
+	const Obliterator = new Janitor<{ CurrentTween: Tween }>();
+	const Part = Workspace.FindFirstChild("Part") as Part;
+
+	// Queue the Part to be Destroyed at Cleanup time
+	Obliterator.Add(Part, "Destroy");
+
+	// Queue function to be called with `true` MethodName
+	Obliterator.Add(print, true);
+
+	// This implementation allows you to specify behavior for any object
+	Obliterator.Add(TweenService.Create(Part, new TweenInfo(1), {Size: new Vector3(1, 1, 1)}), "Cancel");
+
+	// By passing an Index, the Object will occupy a namespace
+	// If "CurrentTween" already exists, it will call :Remove("CurrentTween") before writing
+	Obliterator.Add(TweenService.Create(Part, new TweenInfo(1), {Size: new Vector3(1, 1, 1)}), "Destroy", "CurrentTween");
+	```
+
+	@param Object T -- The object you want to clean up.
+	@param MethodName? string|true -- The name of the method that will be used to clean up. If not passed, it will first check if the object's type exists in TypeDefaults, and if that doesn't exist, it assumes `Destroy`.
+	@param Index? any -- The index that can be used to clean up the object manually.
+	@return T -- The object that was passed as the first argument.
+]=]
+function Janitor:Add(Object: any, MethodName: StringOrTrue?, Index: any?): any
+	if Index then
+		self:Remove(Index)
+
+		local This = self[IndicesReference]
+		if not This then
+			This = {}
+			self[IndicesReference] = This
+		end
+
+		This[Index] = Object
+	end
+
+	MethodName = MethodName or TypeDefaults[typeof(Object)] or "Destroy"
+	if type(Object) ~= "function" and not Object[MethodName] then
+		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(nil :: any, 2)))
+	end
+
+	self[Object] = MethodName
+	return Object
+end
+
+--[=[
+	Adds a [Promise](https://github.com/evaera/roblox-lua-promise) to the Janitor. If the Janitor is cleaned up and the Promise is not completed, the Promise will be cancelled.
+
+	```lua
+	local Obliterator = Janitor.new()
+	Obliterator:AddPromise(Promise.delay(3)):andThenCall(print, "Finished!"):catch(warn)
+	task.wait(1)
+	Obliterator:Cleanup()
+	```
+
+	```ts
+	import { Janitor } from "@rbxts/janitor";
+
+	const Obliterator = new Janitor();
+	Obliterator.AddPromise(Promise.delay(3)).andThenCall(print, "Finished!").catch(warn);
+	task.wait(1);
+	Obliterator.Cleanup();
+	```
+
+	@param PromiseObject Promise -- The promise you want to add to the Janitor.
+	@return Promise
+]=]
+function Janitor:AddPromise(PromiseObject)
+	if FoundPromiseLibrary then
+		if not Promise.is(PromiseObject) then
+			error(string.format(NOT_A_PROMISE, typeof(PromiseObject), tostring(PromiseObject)))
+		end
+
+		if PromiseObject:getStatus() == Promise.Status.Started then
+			local Id = newproxy(false)
+			local NewPromise = self:Add(Promise.new(function(Resolve, _, OnCancel)
+				if OnCancel(function()
+					PromiseObject:cancel()
+				end) then
+					return
+				end
+
+				Resolve(PromiseObject)
+			end), "cancel", Id)
+
+			NewPromise:finallyCall(self.Remove, self, Id)
+			return NewPromise
+		else
+			return PromiseObject
+		end
+	else
+		return PromiseObject
+	end
+end
+
+--[=[
+	Cleans up whatever `Object` was set to this namespace by the 3rd parameter of [Janitor.Add](#Add).
+
+	```lua
+	local Obliterator = Janitor.new()
+	Obliterator:Add(workspace.Baseplate, "Destroy", "Baseplate")
+	Obliterator:Remove("Baseplate")
+	```
+
+	```ts
+	import { Workspace } from "@rbxts/services";
+	import { Janitor } from "@rbxts/janitor";
+
+	const Obliterator = new Janitor<{ Baseplate: Part }>();
+	Obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	Obliterator.Remove("Baseplate");
+	```
+
+	@param Index any -- The index you want to remove.
+	@return Janitor
+]=]
+function Janitor:Remove(Index: any)
+	local This = self[IndicesReference]
+
+	if This then
+		local Object = This[Index]
+
+		if Object then
+			local MethodName = self[Object]
+
+			if MethodName then
+				if MethodName == true then
+					Object()
+				else
+					local ObjectMethod = Object[MethodName]
+					if ObjectMethod then
+						ObjectMethod(Object)
+					end
+				end
+
+				self[Object] = nil
+			end
+
+			This[Index] = nil
+		end
+	end
+
+	return self
+end
+
+--[=[
+	Gets whatever object is stored with the given index, if it exists. This was added since Maid allows getting the task using `__index`.
+
+	```lua
+	local Obliterator = Janitor.new()
+	Obliterator:Add(workspace.Baseplate, "Destroy", "Baseplate")
+	print(Obliterator:Get("Baseplate")) -- Returns Baseplate.
+	```
+
+	```ts
+	import { Workspace } from "@rbxts/services";
+	import { Janitor } from "@rbxts/janitor";
+
+	const Obliterator = new Janitor<{ Baseplate: Part }>();
+	Obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	print(Obliterator.Get("Baseplate")); // Returns Baseplate.
+	```
+
+	@param Index any -- The index that the object is stored under.
+	@return any? -- This will return the object if it is found, but it won't return anything if it doesn't exist.
+]=]
+function Janitor:Get(Index: any): any?
+	local This = self[IndicesReference]
+	if This then
+		return This[Index]
+	else
+		return nil
+	end
+end
+
+local function GetFenv(self)
+	return function()
+		for Object, MethodName in pairs(self) do
+			if Object ~= IndicesReference then
+				return Object, MethodName
+			end
+		end
+	end
+end
+
+--[=[
+	Calls each Object's `MethodName` (or calls the Object if `MethodName == true`) and removes them from the Janitor. Also clears the namespace.
+	This function is also called when you call a Janitor Object (so it can be used as a destructor callback).
+
+	```lua
+	Obliterator:Cleanup() -- Valid.
+	Obliterator() -- Also valid.
+	```
+
+	```ts
+	Obliterator.Cleanup()
+	```
+]=]
+function Janitor:Cleanup()
+	if not self.CurrentlyCleaning then
+		self.CurrentlyCleaning = nil
+
+		local Get = GetFenv(self)
+		local Object, MethodName = Get()
+
+		while Object and MethodName do -- changed to a while loop so that if you add to the janitor inside of a callback it doesn't get untracked (instead it will loop continuously which is a lot better than a hard to pindown edgecase)
+			if MethodName == true then
+				Object()
+			else
+				local ObjectMethod = Object[MethodName]
+				if ObjectMethod then
+					ObjectMethod(Object)
+				end
+			end
+
+			self[Object] = nil
+			Object, MethodName = Get()
+		end
+
+		local This = self[IndicesReference]
+		if This then
+			table.clear(This)
+			self[IndicesReference] = {}
+		end
+
+		self.CurrentlyCleaning = false
+	end
+end
+
+--[=[
+	Calls [Janitor.Cleanup](#Cleanup) and renders the Janitor unusable.
+
+	:::warning
+	Running this will make any attempts to call a function of Janitor error.
+	:::
+]=]
+function Janitor:Destroy()
+	self:Cleanup()
+	table.clear(self)
+	setmetatable(self, nil)
+end
+
+Janitor.__call = Janitor.Cleanup
+
+--[=[
+	A wrapper for an `RBXScriptConnection`. Makes the Janitor clean up when the instance is destroyed. This was created by Corecii.
+
+	@class RbxScriptConnection
+	@__index RbxScriptConnection
+]=]
+local RbxScriptConnection = {}
+RbxScriptConnection.Connected = true
+RbxScriptConnection.__index = RbxScriptConnection
+
+--[=[
+	Disconnects the Signal.
+]=]
+function RbxScriptConnection:Disconnect()
+	if self.Connected then
+		self.Connected = false
+		self.Connection:Disconnect()
+	end
+end
+
+function RbxScriptConnection._new(RBXScriptConnection: RBXScriptConnection)
+	return setmetatable({
+		Connection = RBXScriptConnection;
+	}, RbxScriptConnection)
+end
+
+function RbxScriptConnection:__tostring()
+	return "RbxScriptConnection<" .. tostring(self.Connected) .. ">"
+end
+
+type RbxScriptConnection = typeof(RbxScriptConnection._new(game:GetPropertyChangedSignal("ClassName"):Connect(function() end)))
+
+--[=[
+	"Links" this Janitor to an Instance, such that the Janitor will `Cleanup` when the Instance is `Destroyed()` and garbage collected.
+	A Janitor may only be linked to one instance at a time, unless `AllowMultiple` is true. When called with a truthy `AllowMultiple` parameter,
+	the Janitor will "link" the Instance without overwriting any previous links, and will also not be overwritable.
+	When called with a falsy `AllowMultiple` parameter, the Janitor will overwrite the previous link which was also called with a falsy `AllowMultiple` parameter, if applicable.
+
+	```lua
+	local Obliterator = Janitor.new()
+
+	Obliterator:Add(function()
+		print("Cleaning up!")
+	end, true)
+
+	do
+		local Folder = Instance.new("Folder")
+		Obliterator:LinkToInstance(Folder)
+		Folder:Destroy()
+	end
+	```
+
+	```ts
+	import { Janitor } from "@rbxts/janitor";
+
+	const Obliterator = new Janitor();
+	Obliterator.Add(() => print("Cleaning up!"), true);
+
+	{
+		const Folder = new Instance("Folder");
+		Obliterator.LinkToInstance(Folder, false);
+		Folder.Destroy();
+	}
+	```
+
+	This returns a mock `RBXScriptConnection` (see: [RbxScriptConnection](#RbxScriptConnection)).
+
+	@param Object Instance -- The instance you want to link the Janitor to.
+	@param AllowMultiple? boolean -- Whether or not to allow multiple links on the same Janitor.
+	@return RbxScriptConnection -- A pseudo RBXScriptConnection that can be disconnected to prevent the cleanup of LinkToInstance.
+]=]
+function Janitor:LinkToInstance(Object: Instance, AllowMultiple: boolean?): RbxScriptConnection
+	local Connection
+	local IndexToUse = AllowMultiple and newproxy(false) or LinkToInstanceIndex
+	local IsNilParented = Object.Parent == nil
+	local ManualDisconnect = setmetatable({}, RbxScriptConnection)
+
+	local function ChangedFunction(_DoNotUse, NewParent)
+		if ManualDisconnect.Connected then
+			_DoNotUse = nil
+			IsNilParented = NewParent == nil
+
+			if IsNilParented then
+				task.defer(function()
+					if not ManualDisconnect.Connected then
+						return
+					elseif not Connection.Connected then
+						self:Cleanup()
+					else
+						while IsNilParented and Connection.Connected and ManualDisconnect.Connected do
+							task.wait()
+						end
+
+						if ManualDisconnect.Connected and IsNilParented then
+							self:Cleanup()
+						end
+					end
+				end)
+			end
+		end
+	end
+
+	Connection = Object.AncestryChanged:Connect(ChangedFunction)
+	ManualDisconnect.Connection = Connection
+
+	if IsNilParented then
+		ChangedFunction(nil, Object.Parent)
+	end
+
+	Object = nil :: any
+	return self:Add(ManualDisconnect, "Disconnect", IndexToUse)
+end
+
+--[=[
+	Links several instances to a new Janitor, which is then returned.
+
+	@param ... Instance -- All the Instances you want linked.
+	@return Janitor -- A new Janitor that can be used to manually disconnect all LinkToInstances.
+]=]
+function Janitor:LinkToInstances(...: Instance)
+	local ManualCleanup = Janitor.new()
+	for _, Object in ipairs({...}) do
+		ManualCleanup:Add(self:LinkToInstance(Object, true), "Disconnect")
+	end
+
+	return ManualCleanup
+end
+
+--[=[
+	Instantiates a new Janitor object.
+	@return Janitor
+]=]
+function Janitor.new()
+	return setmetatable({
+		CurrentlyCleaning = false;
+		[IndicesReference] = nil;
+	}, Janitor)
+end
+
+export type Janitor = typeof(Janitor.new())
+return Janitor


### PR DESCRIPTION
As the library grows into a more concrete and highly composite one, there arrive a lot of issues with garbage cleaning and how we handle disconnecting events, destroying objects and instances. As of now, we just don't care about memory leaks! And yes, that is true. We are just hoping, that we don't run into such problems. And this hope dies down as we start using Nature2D for full fledged projects. 

Problems that exist:
* `:Destroy()` methods aren't implemented properly.
* There is no way to destroy the Engine and its entities as a whole.
* There's no way to destroy points properly without messing up other objects.
* Destroying GuiObjects of constraints, points and rigid bodies doesn't destroy their objects (classes) subsequently.
* Its hard to implement garbage cleaning in a library with such a versatile hierarchy of physics objects, without using a maid class.
* For situations like destroying points - we disconnect all events, destroy GuiObjects and its class, its parent constraint and the parent rigid body of the constraint (if any). This is hard to implement with current ways of garbage cleaning.

The library is prone to have memory leaks, but this pull request aims to solve all problems related to memory leaks and garbage cleaning using [Janitor](https://github.com/howmanysmall/Janitor). This PR will remain a draft until all changes have been proposed and revised.